### PR TITLE
Check both statement and connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -27,7 +27,7 @@ func (c wrappedConn) Prepare(query string) (driver.Stmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	return wrappedStmt{intr: c.intr, query: query, parent: stmt}, nil
+	return wrappedStmt{intr: c.intr, query: query, parent: stmt, conn: c}, nil
 }
 
 func (c wrappedConn) Close() error {
@@ -57,7 +57,7 @@ func (c wrappedConn) PrepareContext(ctx context.Context, query string) (stmt dri
 	if err != nil {
 		return nil, err
 	}
-	return wrappedStmt{intr: c.intr, ctx: ctx, query: query, parent: stmt}, nil
+	return wrappedStmt{intr: c.intr, ctx: ctx, query: query, parent: stmt, conn: c}, nil
 }
 
 func (c wrappedConn) Exec(query string, args []driver.Value) (driver.Result, error) {

--- a/conn_go19.go
+++ b/conn_go19.go
@@ -8,10 +8,15 @@ var (
 	_ driver.NamedValueChecker = wrappedConn{}
 )
 
+func defaultCheckNamedValue(nv *driver.NamedValue) (err error) {
+	nv.Value, err = driver.DefaultParameterConverter.ConvertValue(nv.Value)
+	return err
+}
+
 func (c wrappedConn) CheckNamedValue(v *driver.NamedValue) error {
 	if checker, ok := c.parent.(driver.NamedValueChecker); ok {
 		return checker.CheckNamedValue(v)
 	}
 
-	return driver.ErrSkip
+	return defaultCheckNamedValue(v)
 }

--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -1,0 +1,84 @@
+package sqlmw
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+type fakeDriver struct {
+	conn driver.Conn
+}
+
+func (d *fakeDriver) Open(_ string) (driver.Conn, error) {
+	return d.conn, nil
+}
+
+type fakeStmt struct {
+	called bool
+}
+
+type fakeStmtWithCheckNamedValue struct {
+	fakeStmt
+}
+
+type fakeStmtWithoutCheckNamedValue struct {
+	fakeStmt
+}
+
+func (s fakeStmt) Close() error {
+	return nil
+}
+
+func (s fakeStmt) NumInput() int {
+	return 1
+}
+
+func (s fakeStmt) Exec(_ []driver.Value) (driver.Result, error) {
+	return nil, nil
+}
+
+func (s fakeStmt) Query(_ []driver.Value) (driver.Rows, error) {
+	return nil, nil
+}
+
+func (s *fakeStmtWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err error) {
+	s.called = true
+	return
+}
+
+type fakeConn struct {
+	called bool
+	stmt   driver.Stmt
+}
+
+type fakeConnWithCheckNamedValue struct {
+	fakeConn
+}
+
+type fakeConnWithoutCheckNamedValue struct {
+	fakeConn
+}
+
+func (c *fakeConn) Prepare(_ string) (driver.Stmt, error) {
+	return nil, nil
+}
+
+func (c *fakeConn) PrepareContext(_ context.Context, _ string) (driver.Stmt, error) {
+	return c.stmt, nil
+}
+
+func (c *fakeConn) Close() error              { return nil }
+func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
+
+func (c *fakeConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	return nil, nil
+}
+
+func (c *fakeConnWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err error) {
+	c.called = true
+	return
+}
+
+type fakeInterceptor struct {
+	NullInterceptor
+}

--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -68,6 +68,7 @@ func (c *fakeConn) PrepareContext(_ context.Context, _ string) (driver.Stmt, err
 }
 
 func (c *fakeConn) Close() error              { return nil }
+
 func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
 
 func (c *fakeConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {

--- a/stmt.go
+++ b/stmt.go
@@ -10,6 +10,7 @@ type wrappedStmt struct {
 	ctx    context.Context
 	query  string
 	parent driver.Stmt
+	conn   wrappedConn
 }
 
 // Compile time validation that our types implement the expected interfaces

--- a/stmt_go19.go
+++ b/stmt_go19.go
@@ -13,5 +13,5 @@ func (s wrappedStmt) CheckNamedValue(v *driver.NamedValue) error {
 		return checker.CheckNamedValue(v)
 	}
 
-	return driver.ErrSkip
+	return defaultCheckNamedValue(v)
 }

--- a/stmt_go19.go
+++ b/stmt_go19.go
@@ -4,8 +4,12 @@ import "database/sql/driver"
 
 var _ driver.NamedValueChecker = wrappedStmt{}
 
-func (c wrappedStmt) CheckNamedValue(v *driver.NamedValue) error {
-	if checker, ok := c.parent.(driver.NamedValueChecker); ok {
+func (s wrappedStmt) CheckNamedValue(v *driver.NamedValue) error {
+	if checker, ok := s.parent.(driver.NamedValueChecker); ok {
+		return checker.CheckNamedValue(v)
+	}
+
+	if checker, ok := s.conn.parent.(driver.NamedValueChecker); ok {
 		return checker.CheckNamedValue(v)
 	}
 

--- a/stmt_go19_test.go
+++ b/stmt_go19_test.go
@@ -1,0 +1,106 @@
+package sqlmw
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+)
+
+func TestWrappedStmt_CheckNamedValue(t *testing.T) {
+	tests := map[string]struct {
+		fd       *fakeDriver
+		expected struct {
+			cc bool // Whether the fakeConn's CheckNamedValue was called
+			sc bool // Whether the fakeStmt's CheckNamedValue was called
+		}
+	}{
+		"When both conn and stmt implement CheckNamedValue": {
+			fd: &fakeDriver{
+				conn: &fakeConnWithCheckNamedValue{
+					fakeConn: fakeConn{
+						stmt: &fakeStmtWithCheckNamedValue{},
+					},
+				},
+			},
+			expected: struct {
+				cc bool
+				sc bool
+			}{cc: false, sc: true},
+		},
+		"When only conn implements CheckNamedValue": {
+			fd: &fakeDriver{
+				conn: &fakeConnWithCheckNamedValue{
+					fakeConn: fakeConn{
+						stmt: &fakeStmtWithoutCheckNamedValue{},
+					},
+				},
+			},
+			expected: struct {
+				cc bool
+				sc bool
+			}{cc: true, sc: false},
+		},
+		"When only stmt implements CheckNamedValue": {
+			fd: &fakeDriver{
+				conn: &fakeConnWithoutCheckNamedValue{
+					fakeConn: fakeConn{
+						stmt: &fakeStmtWithCheckNamedValue{},
+					},
+				},
+			},
+			expected: struct {
+				cc bool
+				sc bool
+			}{cc: false, sc: true},
+		},
+		"When both stmt do not implement CheckNamedValue": {
+			fd: &fakeDriver{
+				conn: &fakeConnWithoutCheckNamedValue{
+					fakeConn: fakeConn{
+						stmt: &fakeStmtWithoutCheckNamedValue{},
+					},
+				},
+			},
+			expected: struct {
+				cc bool
+				sc bool
+			}{cc: false, sc: false},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sql.Register("fake-driver:"+name, Driver(test.fd, &fakeInterceptor{}))
+			db, err := sql.Open("fake-driver:"+name, "dummy")
+			if err != nil {
+				t.Errorf("Failed to open: %v", err)
+			}
+			defer func() {
+				if err := db.Close(); err != nil {
+					t.Errorf("Failed to close db: %v", err)
+				}
+			}()
+
+			stmt, err := db.Prepare("SELECT foo FROM bar Where 1 = ?")
+			if err != nil {
+				t.Errorf("Failed to prepare: %v", err)
+			}
+
+			if _, err := stmt.Query(1); err != nil {
+				t.Errorf("Failed to query: %v", err)
+			}
+
+			conn := reflect.ValueOf(test.fd.conn).Elem()
+			sc := conn.FieldByName("stmt").Elem().Elem().FieldByName("called").Bool()
+			cc := conn.FieldByName("called").Bool()
+
+			if test.expected.sc != sc {
+				t.Errorf("sc mismatch.\n got: %#v\nwant: %#v", sc, test.expected.sc)
+			}
+
+			if test.expected.cc != cc {
+				t.Errorf("cc mismatch.\n got: %#v\nwant: %#v", cc, test.expected.cc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I would like to use sqlmw with MySQLDriver ( https://github.com/go-sql-driver/mysql ),
but I got the following error.


Code
```go
import (
	"context"
	"database/sql"
	"database/sql/driver"
	"fmt"
	"time"

	"github.com/go-sql-driver/mysql"
	"github.com/ngrok/sqlmw"
)

func run(dsn string) {
        // install the wrapped driver
        sql.Register("mysql-mw", sqlmw.Driver(mysql.MySQLDriver{}, new(sqlInterceptor)))
        sql.Open("mysql-mw", dsn)
}

type sqlInterceptor struct {
        sqlmw.NullInterceptor
}

func (in *sqlInterceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQueryContext, query string, args []driver.NamedValue) (driver.Rows, error) {
        startedAt := time.Now()
        rows, err := conn.QueryContext(ctx, args)
        log.Debug("executed sql query", "duration", time.Since(startedAt), "query", query, "args", args, "err", err)
        return rows, err
}
```

error:
```
panic: sql: converting argument $1 type: driver ColumnConverter error converted uint64 to unsupported type uint64
```


According to my investigation, 
it was not forwarded to `mysql.mysqlConn` ( `sqlmw.wrappedConn` ) from `mysql.mysqlStmt` ( `sqlmw.wrappedStmt` ) in the following places, 
so the type conversion did not seem to be performed.
https://github.com/golang/go/blob/release-branch.go1.9/src/database/sql/convert.go#L136-L139

So, I changed `CheckNamedValue` of `wrappedStmt` to check both statement and connection.
