### PR TITLE
call stmt.ColumnConverter when implemented by parent statement

### DIFF
--- a/conn_go19.go
+++ b/conn_go19.go
@@ -8,15 +8,10 @@ var (
 	_ driver.NamedValueChecker = wrappedConn{}
 )
 
-func defaultCheckNamedValue(nv *driver.NamedValue) (err error) {
-	nv.Value, err = driver.DefaultParameterConverter.ConvertValue(nv.Value)
-	return err
-}
-
 func (c wrappedConn) CheckNamedValue(v *driver.NamedValue) error {
 	if checker, ok := c.parent.(driver.NamedValueChecker); ok {
 		return checker.CheckNamedValue(v)
 	}
 
-	return defaultCheckNamedValue(v)
+	return driver.ErrSkip
 }

--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -14,7 +14,8 @@ func (d *fakeDriver) Open(_ string) (driver.Conn, error) {
 }
 
 type fakeStmt struct {
-	called bool
+	checkNamedValueCalled bool
+	columnConverterCalled bool
 }
 
 type fakeStmtWithCheckNamedValue struct {
@@ -22,6 +23,10 @@ type fakeStmtWithCheckNamedValue struct {
 }
 
 type fakeStmtWithoutCheckNamedValue struct {
+	fakeStmt
+}
+
+type fakeStmtWithColumnConverter struct {
 	fakeStmt
 }
 
@@ -41,8 +46,13 @@ func (s fakeStmt) Query(_ []driver.Value) (driver.Rows, error) {
 	return nil, nil
 }
 
+func (s *fakeStmtWithColumnConverter) ColumnConverter(_ int) driver.ValueConverter {
+	s.columnConverterCalled = true
+	return driver.DefaultParameterConverter
+}
+
 func (s *fakeStmtWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err error) {
-	s.called = true
+	s.checkNamedValueCalled = true
 	return
 }
 
@@ -67,7 +77,7 @@ func (c *fakeConn) PrepareContext(_ context.Context, _ string) (driver.Stmt, err
 	return c.stmt, nil
 }
 
-func (c *fakeConn) Close() error              { return nil }
+func (c *fakeConn) Close() error { return nil }
 
 func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
 

--- a/stmt_go19.go
+++ b/stmt_go19.go
@@ -13,5 +13,5 @@ func (s wrappedStmt) CheckNamedValue(v *driver.NamedValue) error {
 		return checker.CheckNamedValue(v)
 	}
 
-	return defaultCheckNamedValue(v)
+	return driver.ErrSkip
 }


### PR DESCRIPTION
According to the stdlib driver documentation
(https://github.com/golang/go/blob/bc51e930274a5d5835ac8797978afc0864c9e30c/src/database/sql/driver/driver.go#L385)
value checkers should be called in the following order:

> [..] stopping at the first found match: Stmt.NamedValueChecker,
> Conn.NamedValueChecker, Stmt.ColumnConverter,
> DefaultParameterConverter.

sqlmw was not calling Stmt.ColumnConverter when it was implemented.

This commit changes the behavior to call Stmt.ColumnConverter, if it is
implemented and the NamedValueCheckers are not implemented.
This is done by returning ErrSkip in wrappedStmt.CheckNamedValue() if
neither the parent statement nor the conn implements CheckNamedValue.
The sql package will call wrappedStmt.ColumnConverter() if ErrSkip was
returned.

wrappedStmt.CheckNamedValue() can not check only if the stmt
implements CheckNamedValue and return ErrSkip.
It must also call CheckNamedValue() on the connection if it
was not implemented for the stmt. This is because the stdlib sql package
calls wrappedStmt.CheckNamedValue() if is implemented on the stmt OR on
the connection.

The commit also adds a testcase to verify that ColumnConverter is
called.