### PR TITLE
support intercepting Rows.Close() calls

### DIFF
--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -56,9 +56,28 @@ func (s *fakeStmtWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err
 	return
 }
 
+type fakeRows struct {
+	con         *fakeConn
+	closeCalled bool
+}
+
+func (r *fakeRows) Close() error {
+	r.con.rowsCloseCalled = true
+	return nil
+}
+
+func (r *fakeRows) Columns() []string {
+	return nil
+}
+
+func (r *fakeRows) Next(_ []driver.Value) error {
+	return nil
+}
+
 type fakeConn struct {
-	called bool
-	stmt   driver.Stmt
+	called          bool
+	rowsCloseCalled bool
+	stmt            driver.Stmt
 }
 
 type fakeConnWithCheckNamedValue struct {
@@ -82,7 +101,7 @@ func (c *fakeConn) Close() error { return nil }
 func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
 
 func (c *fakeConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
-	return nil, nil
+	return &fakeRows{con: c}, nil
 }
 
 func (c *fakeConnWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err error) {

--- a/interceptor.go
+++ b/interceptor.go
@@ -22,6 +22,7 @@ type Interceptor interface {
 
 	// Rows interceptors
 	RowsNext(context.Context, driver.Rows, []driver.Value) error
+	RowsClose(context.Context, driver.Rows) error
 
 	// Stmt interceptors
 	StmtExecContext(context.Context, driver.StmtExecContext, string, []driver.NamedValue) (driver.Result, error)
@@ -74,6 +75,10 @@ func (NullInterceptor) ResultRowsAffected(res driver.Result) (int64, error) {
 
 func (NullInterceptor) RowsNext(ctx context.Context, rows driver.Rows, dest []driver.Value) error {
 	return rows.Next(dest)
+}
+
+func (NullInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
+	return rows.Close()
 }
 
 func (NullInterceptor) StmtExecContext(ctx context.Context, stmt driver.StmtExecContext, _ string, args []driver.NamedValue) (driver.Result, error) {

--- a/interceptor.go
+++ b/interceptor.go
@@ -22,7 +22,7 @@ type Interceptor interface {
 
 	// Rows interceptors
 	RowsNext(context.Context, driver.Rows, []driver.Value) error
-	RowsClose(context.Context, driver.Rows) error
+	RowsClose(driver.Rows) error
 
 	// Stmt interceptors
 	StmtExecContext(context.Context, driver.StmtExecContext, string, []driver.NamedValue) (driver.Result, error)
@@ -77,7 +77,7 @@ func (NullInterceptor) RowsNext(ctx context.Context, rows driver.Rows, dest []dr
 	return rows.Next(dest)
 }
 
-func (NullInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
+func (NullInterceptor) RowsClose(rows driver.Rows) error {
 	return rows.Close()
 }
 

--- a/interceptor.go
+++ b/interceptor.go
@@ -22,7 +22,7 @@ type Interceptor interface {
 
 	// Rows interceptors
 	RowsNext(context.Context, driver.Rows, []driver.Value) error
-	RowsClose(driver.Rows) error
+	RowsClose(context.Context, driver.Rows) error
 
 	// Stmt interceptors
 	StmtExecContext(context.Context, driver.StmtExecContext, string, []driver.NamedValue) (driver.Result, error)
@@ -77,7 +77,7 @@ func (NullInterceptor) RowsNext(ctx context.Context, rows driver.Rows, dest []dr
 	return rows.Next(dest)
 }
 
-func (NullInterceptor) RowsClose(rows driver.Rows) error {
+func (NullInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
 	return rows.Close()
 }
 

--- a/rows.go
+++ b/rows.go
@@ -27,7 +27,7 @@ func (r wrappedRows) Columns() []string {
 }
 
 func (r wrappedRows) Close() error {
-	return r.intr.RowsClose(r.ctx, r.parent)
+	return r.intr.RowsClose(r.parent)
 }
 
 func (r wrappedRows) Next(dest []driver.Value) (err error) {

--- a/rows.go
+++ b/rows.go
@@ -27,7 +27,7 @@ func (r wrappedRows) Columns() []string {
 }
 
 func (r wrappedRows) Close() error {
-	return r.parent.Close()
+	return r.intr.RowsClose(r.ctx, r.parent)
 }
 
 func (r wrappedRows) Next(dest []driver.Value) (err error) {

--- a/rows.go
+++ b/rows.go
@@ -27,7 +27,7 @@ func (r wrappedRows) Columns() []string {
 }
 
 func (r wrappedRows) Close() error {
-	return r.intr.RowsClose(r.parent)
+	return r.intr.RowsClose(r.ctx, r.parent)
 }
 
 func (r wrappedRows) Next(dest []driver.Value) (err error) {

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,0 +1,77 @@
+package sqlmw
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+)
+
+type rowsCloseInterceptor struct {
+	NullInterceptor
+
+	rowsCloseCalled  bool
+	rowsCloseLastCtx context.Context
+}
+
+func (r *rowsCloseInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
+	r.rowsCloseCalled = true
+	r.rowsCloseLastCtx = ctx
+
+	return rows.Close()
+}
+
+func TestRowsClose(t *testing.T) {
+	driverName := t.Name()
+	interceptor := rowsCloseInterceptor{}
+
+	con := fakeConn{}
+	sql.Register(driverName, Driver(&fakeDriver{conn: &con}, &interceptor))
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("opening db failed: %s", err)
+	}
+
+	ctx := context.Background()
+	ctxKey := "ctxkey"
+	ctxVal := "1"
+
+	ctx = context.WithValue(ctx, ctxKey, ctxVal)
+
+	rows, err := db.QueryContext(ctx, "", "")
+	if err != nil {
+		t.Fatalf("db.Query failed: %s", err)
+	}
+
+	err = rows.Close()
+	if err != nil {
+		t.Errorf("rows Close failed: %s", err)
+	}
+
+	if !interceptor.rowsCloseCalled {
+		t.Error("interceptor rows.Close was not called")
+	}
+
+	if interceptor.rowsCloseLastCtx == nil {
+		t.Fatal("rows close ctx is nil")
+	}
+
+	v := interceptor.rowsCloseLastCtx.Value(ctxKey)
+	if v == nil {
+		t.Fatalf("ctx is different, missing value for key: %s", ctxKey)
+	}
+
+	vStr, ok := v.(string)
+	if !ok {
+		t.Fatalf("ctx is different, value for key: %s, has type %t, expected string", ctxKey, v)
+	}
+
+	if ctxVal != vStr {
+		t.Errorf("ctx is different, value for key: %s, is %q, expected %q", ctxKey, vStr, ctxVal)
+	}
+
+	if !con.rowsCloseCalled {
+		t.Fatalf("rows close of driver was not called")
+	}
+}


### PR DESCRIPTION
Add a new RowsClose() method to the interceptor interface to which
rows.Close() calls are forwarded.

Intercepting rows.Close() can be useful in tracing middlewares.
It allows to create a parent span when the db Rows object is
created, create child spans for operations on the Rows and finish the
parent span when rows.Close() is called.