### PR TITLE
Revert "call stmt.ColumnConverter when implemented by parent statement"

### DIFF
--- a/conn_go19.go
+++ b/conn_go19.go
@@ -8,10 +8,15 @@ var (
 	_ driver.NamedValueChecker = wrappedConn{}
 )
 
+func defaultCheckNamedValue(nv *driver.NamedValue) (err error) {
+	nv.Value, err = driver.DefaultParameterConverter.ConvertValue(nv.Value)
+	return err
+}
+
 func (c wrappedConn) CheckNamedValue(v *driver.NamedValue) error {
 	if checker, ok := c.parent.(driver.NamedValueChecker); ok {
 		return checker.CheckNamedValue(v)
 	}
 
-	return driver.ErrSkip
+	return defaultCheckNamedValue(v)
 }

--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -14,8 +14,7 @@ func (d *fakeDriver) Open(_ string) (driver.Conn, error) {
 }
 
 type fakeStmt struct {
-	checkNamedValueCalled bool
-	columnConverterCalled bool
+	called bool
 }
 
 type fakeStmtWithCheckNamedValue struct {
@@ -23,10 +22,6 @@ type fakeStmtWithCheckNamedValue struct {
 }
 
 type fakeStmtWithoutCheckNamedValue struct {
-	fakeStmt
-}
-
-type fakeStmtWithColumnConverter struct {
 	fakeStmt
 }
 
@@ -46,13 +41,8 @@ func (s fakeStmt) Query(_ []driver.Value) (driver.Rows, error) {
 	return nil, nil
 }
 
-func (s *fakeStmtWithColumnConverter) ColumnConverter(_ int) driver.ValueConverter {
-	s.columnConverterCalled = true
-	return driver.DefaultParameterConverter
-}
-
 func (s *fakeStmtWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err error) {
-	s.checkNamedValueCalled = true
+	s.called = true
 	return
 }
 
@@ -96,7 +86,7 @@ func (c *fakeConn) PrepareContext(_ context.Context, _ string) (driver.Stmt, err
 	return c.stmt, nil
 }
 
-func (c *fakeConn) Close() error { return nil }
+func (c *fakeConn) Close() error              { return nil }
 
 func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
 

--- a/stmt_go19.go
+++ b/stmt_go19.go
@@ -13,5 +13,5 @@ func (s wrappedStmt) CheckNamedValue(v *driver.NamedValue) error {
 		return checker.CheckNamedValue(v)
 	}
 
-	return driver.ErrSkip
+	return defaultCheckNamedValue(v)
 }

--- a/stmt_go19_test.go
+++ b/stmt_go19_test.go
@@ -10,10 +10,8 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 	tests := map[string]struct {
 		fd       *fakeDriver
 		expected struct {
-			cc  bool // Whether the fakeConn's CheckNamedValue was called
-			sc  bool // Whether the fakeStmt's CheckNamedValue was called
-			cci bool // Whether the fakeStmt's ColumnConverter was called
-
+			cc bool // Whether the fakeConn's CheckNamedValue was called
+			sc bool // Whether the fakeStmt's CheckNamedValue was called
 		}
 	}{
 		"When both conn and stmt implement CheckNamedValue": {
@@ -25,9 +23,8 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 				},
 			},
 			expected: struct {
-				cc  bool
-				sc  bool
-				cci bool
+				cc bool
+				sc bool
 			}{cc: false, sc: true},
 		},
 		"When only conn implements CheckNamedValue": {
@@ -39,9 +36,8 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 				},
 			},
 			expected: struct {
-				cc  bool
-				sc  bool
-				cci bool
+				cc bool
+				sc bool
 			}{cc: true, sc: false},
 		},
 		"When only stmt implements CheckNamedValue": {
@@ -53,24 +49,9 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 				},
 			},
 			expected: struct {
-				cc  bool
-				sc  bool
-				cci bool
+				cc bool
+				sc bool
 			}{cc: false, sc: true},
-		},
-		"When only stmt implements ColumnConverter": {
-			fd: &fakeDriver{
-				conn: &fakeConnWithoutCheckNamedValue{
-					fakeConn: fakeConn{
-						stmt: &fakeStmtWithColumnConverter{},
-					},
-				},
-			},
-			expected: struct {
-				cc  bool
-				sc  bool
-				cci bool
-			}{cci: true},
 		},
 		"When both stmt do not implement CheckNamedValue": {
 			fd: &fakeDriver{
@@ -81,9 +62,8 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 				},
 			},
 			expected: struct {
-				cc  bool
-				sc  bool
-				cci bool
+				cc bool
+				sc bool
 			}{cc: false, sc: false},
 		},
 	}
@@ -111,9 +91,8 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 			}
 
 			conn := reflect.ValueOf(test.fd.conn).Elem()
-			sc := conn.FieldByName("stmt").Elem().Elem().FieldByName("checkNamedValueCalled").Bool()
+			sc := conn.FieldByName("stmt").Elem().Elem().FieldByName("called").Bool()
 			cc := conn.FieldByName("called").Bool()
-			cci := conn.FieldByName("stmt").Elem().Elem().FieldByName("columnConverterCalled").Bool()
 
 			if test.expected.sc != sc {
 				t.Errorf("sc mismatch.\n got: %#v\nwant: %#v", sc, test.expected.sc)
@@ -121,10 +100,6 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 
 			if test.expected.cc != cc {
 				t.Errorf("cc mismatch.\n got: %#v\nwant: %#v", cc, test.expected.cc)
-			}
-
-			if test.expected.cci != cci {
-				t.Errorf("columnConverterCalled mismatch.\n got: %#v\nwant: %#v", cci, test.expected.cci)
 			}
 		})
 	}


### PR DESCRIPTION
My change caused that driver.DefaultParameterConverter is not called
anymore sometimes.
For example when the lib/pq driver is used, uint32 args passed to
stmt.Exec() are not converted by driver.DefaultParameterConverter to
int64 anymore.
This causes that the lib/pq driver operation fails because the argument
is passed unconverted, as unsupported type.

I could not reproduce the behavior in a testcase with the fakedb driver.
The driver.DefaultParameterConverter was called and the type was passed
converted to stmt.Exec(), as expected.

I don't understand yet why this happens with the lib/pq driver with my
change.

Revert it for now. That the deprecated ColumnConverter is not called by
sqlmw, is a lesser issue compared to the one that was introduced by my
change.