### PR TITLE
tests: add test that ensures driver.DefaultParameterConverter is used

### DIFF
--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -25,6 +25,16 @@ type fakeStmtWithoutCheckNamedValue struct {
 	fakeStmt
 }
 
+type fakeStmtWithValStore struct {
+	fakeStmt
+	val []driver.Value
+}
+
+func (s *fakeStmtWithValStore) Query(v []driver.Value) (driver.Rows, error) {
+	s.val = v
+	return nil, nil
+}
+
 func (s fakeStmt) Close() error {
 	return nil
 }
@@ -86,7 +96,7 @@ func (c *fakeConn) PrepareContext(_ context.Context, _ string) (driver.Stmt, err
 	return c.stmt, nil
 }
 
-func (c *fakeConn) Close() error              { return nil }
+func (c *fakeConn) Close() error { return nil }
 
 func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
 


### PR DESCRIPTION
Add a testcases that ensures the driver.DefaultParameterConverter is
used to convert db args for stmts when neither the stmt nor con
implements any value converter methods.


I wrote the testcase while debugging https://github.com/ngrok/sqlmw/pull/11.
It succeeded and could not reproduce the issue that I encountered with the lib/pq driver.
It could still be merged to master, does not harm to have more testcases that ensures sqlmw behaves as it should. :-)