### PR TITLE
Setup CI using github-actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,43 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: build
+        run: go build -v ./...
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Test
+        run: go test -v -race ./...
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: golangci-lint
+        run: docker run -v $GITHUB_WORKSPACE:/repo -w /repo golangci/golangci-lint:v1.42 golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+issues:
+  exclude:
+    - "SA1019: .* has been deprecated since Go 1.*: Drivers should implement .*"

--- a/connector.go
+++ b/connector.go
@@ -25,14 +25,6 @@ func (c wrappedConnector) Connect(ctx context.Context) (conn driver.Conn, err er
 	return wrappedConn{intr: c.driverRef.intr, parent: conn}, nil
 }
 
-func (c wrappedConnector) connect(ctx context.Context) (driver.Conn, error) {
-	conn, err := c.parent.Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return wrappedConn{intr: c.driverRef.intr, parent: conn}, err
-}
-
 func (c wrappedConnector) Driver() driver.Driver {
 	return c.driverRef
 }

--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -14,7 +14,7 @@ func (d *fakeDriver) Open(_ string) (driver.Conn, error) {
 }
 
 type fakeStmt struct {
-	called bool
+	called bool // nolint:structcheck // ignore unused warning, it is accessed via reflection
 }
 
 type fakeStmtWithCheckNamedValue struct {
@@ -48,7 +48,7 @@ func (s *fakeStmtWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err
 
 type fakeRows struct {
 	con         *fakeConn
-	closeCalled bool
+	closeCalled bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
 }
 
 func (r *fakeRows) Close() error {
@@ -65,7 +65,7 @@ func (r *fakeRows) Next(_ []driver.Value) error {
 }
 
 type fakeConn struct {
-	called          bool
+	called          bool // nolint:structcheck // ignore unused warning, it is accessed via reflection
 	rowsCloseCalled bool
 	stmt            driver.Stmt
 }
@@ -86,7 +86,7 @@ func (c *fakeConn) PrepareContext(_ context.Context, _ string) (driver.Stmt, err
 	return c.stmt, nil
 }
 
-func (c *fakeConn) Close() error              { return nil }
+func (c *fakeConn) Close() error { return nil }
 
 func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -37,7 +37,7 @@ func TestRowsClose(t *testing.T) {
 	ctxKey := "ctxkey"
 	ctxVal := "1"
 
-	ctx = context.WithValue(ctx, ctxKey, ctxVal)
+	ctx = context.WithValue(ctx, ctxKey, ctxVal) // nolint: staticcheck // not using a custom type for the ctx key is not an issue here
 
 	rows, err := db.QueryContext(ctx, "", "")
 	if err != nil {


### PR DESCRIPTION
The PR introduces a basic CI setup using github-actions.
sqlmw is build and tested with the newest go version, static checks are run via golangci-lint.

Code annotations were added to silence non-relevant golangci-lint warnings and an unused private method was removed that was found by golangci-lint