### PR TITLE
interceptor: remove ctx parameter from db methods that do not have it

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,9 @@ Go versions 1.9 and forward are supported.
 ## Fork
 
 This project began by forking the code in github.com/luna-duclos/instrumentedsql, which itself is a fork of github.com/ExpansiveWorlds/instrumentedsql
+
+## Breaking Changes
+
+- unversioned -> 0.1.0
+  - The `context.Context` parameter was removed from interceptor methods
+	`RowsNext`, `StmtClose`, `TxCommit` and `TxRollback`. [(#14)](https://github.com/ngrok/sqlmw/pull/14)

--- a/conn.go
+++ b/conn.go
@@ -48,7 +48,7 @@ func (c wrappedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx dri
 	if err != nil {
 		return nil, err
 	}
-	return wrappedTx{intr: c.intr, ctx: ctx, parent: tx}, nil
+	return wrappedTx{intr: c.intr, parent: tx}, nil
 }
 
 func (c wrappedConn) PrepareContext(ctx context.Context, query string) (stmt driver.Stmt, err error) {
@@ -57,7 +57,7 @@ func (c wrappedConn) PrepareContext(ctx context.Context, query string) (stmt dri
 	if err != nil {
 		return nil, err
 	}
-	return wrappedStmt{intr: c.intr, ctx: ctx, query: query, parent: stmt, conn: c}, nil
+	return wrappedStmt{intr: c.intr, query: query, parent: stmt, conn: c}, nil
 }
 
 func (c wrappedConn) Exec(query string, args []driver.Value) (driver.Result, error) {
@@ -78,7 +78,7 @@ func (c wrappedConn) ExecContext(ctx context.Context, query string, args []drive
 	if err != nil {
 		return nil, err
 	}
-	return wrappedResult{intr: c.intr, ctx: ctx, parent: r}, nil
+	return wrappedResult{intr: c.intr, parent: r}, nil
 }
 
 func (c wrappedConn) Ping(ctx context.Context) (err error) {
@@ -113,7 +113,7 @@ func (c wrappedConn) QueryContext(ctx context.Context, query string, args []driv
 		return nil, err
 	}
 
-	return wrappedRows{intr: c.intr, ctx: ctx, parent: rows}, nil
+	return wrappedRows{intr: c.intr, parent: rows}, nil
 }
 
 type wrappedParentConn struct {

--- a/interceptor.go
+++ b/interceptor.go
@@ -21,17 +21,17 @@ type Interceptor interface {
 	ResultRowsAffected(driver.Result) (int64, error)
 
 	// Rows interceptors
-	RowsNext(context.Context, driver.Rows, []driver.Value) error
-	RowsClose(context.Context, driver.Rows) error
+	RowsNext(driver.Rows, []driver.Value) error
+	RowsClose(driver.Rows) error
 
 	// Stmt interceptors
 	StmtExecContext(context.Context, driver.StmtExecContext, string, []driver.NamedValue) (driver.Result, error)
 	StmtQueryContext(context.Context, driver.StmtQueryContext, string, []driver.NamedValue) (driver.Rows, error)
-	StmtClose(context.Context, driver.Stmt) error
+	StmtClose(driver.Stmt) error
 
 	// Tx interceptors
-	TxCommit(context.Context, driver.Tx) error
-	TxRollback(context.Context, driver.Tx) error
+	TxCommit(driver.Tx) error
+	TxRollback(driver.Tx) error
 }
 
 var _ Interceptor = NullInterceptor{}
@@ -73,11 +73,11 @@ func (NullInterceptor) ResultRowsAffected(res driver.Result) (int64, error) {
 	return res.RowsAffected()
 }
 
-func (NullInterceptor) RowsNext(ctx context.Context, rows driver.Rows, dest []driver.Value) error {
+func (NullInterceptor) RowsNext(rows driver.Rows, dest []driver.Value) error {
 	return rows.Next(dest)
 }
 
-func (NullInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
+func (NullInterceptor) RowsClose(rows driver.Rows) error {
 	return rows.Close()
 }
 
@@ -89,14 +89,14 @@ func (NullInterceptor) StmtQueryContext(ctx context.Context, stmt driver.StmtQue
 	return stmt.QueryContext(ctx, args)
 }
 
-func (NullInterceptor) StmtClose(ctx context.Context, stmt driver.Stmt) error {
+func (NullInterceptor) StmtClose(stmt driver.Stmt) error {
 	return stmt.Close()
 }
 
-func (NullInterceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
+func (NullInterceptor) TxCommit(tx driver.Tx) error {
 	return tx.Commit()
 }
 
-func (NullInterceptor) TxRollback(ctx context.Context, tx driver.Tx) error {
+func (NullInterceptor) TxRollback(tx driver.Tx) error {
 	return tx.Rollback()
 }

--- a/result.go
+++ b/result.go
@@ -1,13 +1,11 @@
 package sqlmw
 
 import (
-	"context"
 	"database/sql/driver"
 )
 
 type wrappedResult struct {
 	intr   Interceptor
-	ctx    context.Context
 	parent driver.Result
 }
 

--- a/rows.go
+++ b/rows.go
@@ -1,7 +1,6 @@
 package sqlmw
 
 import (
-	"context"
 	"database/sql/driver"
 )
 
@@ -18,7 +17,6 @@ var (
 
 type wrappedRows struct {
 	intr   Interceptor
-	ctx    context.Context
 	parent driver.Rows
 }
 
@@ -27,9 +25,9 @@ func (r wrappedRows) Columns() []string {
 }
 
 func (r wrappedRows) Close() error {
-	return r.intr.RowsClose(r.ctx, r.parent)
+	return r.intr.RowsClose(r.parent)
 }
 
 func (r wrappedRows) Next(dest []driver.Value) (err error) {
-	return r.intr.RowsNext(r.ctx, r.parent, dest)
+	return r.intr.RowsNext(r.parent, dest)
 }

--- a/stmt.go
+++ b/stmt.go
@@ -7,7 +7,6 @@ import (
 
 type wrappedStmt struct {
 	intr   Interceptor
-	ctx    context.Context
 	query  string
 	parent driver.Stmt
 	conn   wrappedConn
@@ -22,7 +21,7 @@ var (
 )
 
 func (s wrappedStmt) Close() (err error) {
-	return s.intr.StmtClose(s.ctx, s.parent)
+	return s.intr.StmtClose(s.parent)
 }
 
 func (s wrappedStmt) NumInput() int {
@@ -34,7 +33,7 @@ func (s wrappedStmt) Exec(args []driver.Value) (res driver.Result, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return wrappedResult{intr: s.intr, ctx: s.ctx, parent: res}, nil
+	return wrappedResult{intr: s.intr, parent: res}, nil
 }
 
 func (s wrappedStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
@@ -42,7 +41,7 @@ func (s wrappedStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return wrappedRows{intr: s.intr, ctx: s.ctx, parent: rows}, nil
+	return wrappedRows{intr: s.intr, parent: rows}, nil
 }
 
 func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res driver.Result, err error) {
@@ -51,7 +50,7 @@ func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 	if err != nil {
 		return nil, err
 	}
-	return wrappedResult{intr: s.intr, ctx: ctx, parent: res}, nil
+	return wrappedResult{intr: s.intr, parent: res}, nil
 }
 
 func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
@@ -60,7 +59,7 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	if err != nil {
 		return nil, err
 	}
-	return wrappedRows{intr: s.intr, ctx: ctx, parent: rows}, nil
+	return wrappedRows{intr: s.intr, parent: rows}, nil
 }
 
 func (s wrappedStmt) ColumnConverter(idx int) driver.ValueConverter {

--- a/tx.go
+++ b/tx.go
@@ -1,13 +1,11 @@
 package sqlmw
 
 import (
-	"context"
 	"database/sql/driver"
 )
 
 type wrappedTx struct {
 	intr   Interceptor
-	ctx    context.Context
 	parent driver.Tx
 }
 
@@ -17,9 +15,9 @@ var (
 )
 
 func (t wrappedTx) Commit() (err error) {
-	return t.intr.TxCommit(t.ctx, t.parent)
+	return t.intr.TxCommit(t.parent)
 }
 
 func (t wrappedTx) Rollback() (err error) {
-	return t.intr.TxRollback(t.ctx, t.parent)
+	return t.intr.TxRollback(t.parent)
 }


### PR DESCRIPTION
The middleware was storing the context that was passed to methods
creating Rows, Tx and Stmts in the wrapped versions of those.
The ctx was then forwarded to operations like RowsNext, RowsClose,
StmtClose.
The related methods do not have a context parameter in the related db
methods in the stdlib.
That ctx was stored in the wrapped objects is probably a remaining of
the instrumentedsql package, that this package is forked from.
For the instrumentedsql package it made sense to store the ctx in the
wrapped object, because it contained tracing spans that could then be
accessed in RowsNext, RowsClose, etc.

For sqlmw it does not.
That the method signatures differs and context from different methods
were forwarded can be confusing. It was not clear for the user which
context he received in those interceptor methods.
The signatures of DB methods of the interceptor should ideally be as
close as possible to those of the stdlib db object.