### PR TITLE
interceptor: remove query arg from StmtExecContext and StmtQueryContext

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -25,8 +25,8 @@ type Interceptor interface {
 	RowsClose(context.Context, driver.Rows) error
 
 	// Stmt interceptors
-	StmtExecContext(context.Context, driver.StmtExecContext, string, []driver.NamedValue) (driver.Result, error)
-	StmtQueryContext(context.Context, driver.StmtQueryContext, string, []driver.NamedValue) (driver.Rows, error)
+	StmtExecContext(context.Context, driver.StmtExecContext, []driver.NamedValue) (driver.Result, error)
+	StmtQueryContext(context.Context, driver.StmtQueryContext, []driver.NamedValue) (driver.Rows, error)
 	StmtClose(context.Context, driver.Stmt) error
 
 	// Tx interceptors
@@ -81,11 +81,11 @@ func (NullInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
 	return rows.Close()
 }
 
-func (NullInterceptor) StmtExecContext(ctx context.Context, stmt driver.StmtExecContext, _ string, args []driver.NamedValue) (driver.Result, error) {
+func (NullInterceptor) StmtExecContext(ctx context.Context, stmt driver.StmtExecContext, args []driver.NamedValue) (driver.Result, error) {
 	return stmt.ExecContext(ctx, args)
 }
 
-func (NullInterceptor) StmtQueryContext(ctx context.Context, stmt driver.StmtQueryContext, _ string, args []driver.NamedValue) (driver.Rows, error) {
+func (NullInterceptor) StmtQueryContext(ctx context.Context, stmt driver.StmtQueryContext, args []driver.NamedValue) (driver.Rows, error) {
 	return stmt.QueryContext(ctx, args)
 }
 

--- a/stmt.go
+++ b/stmt.go
@@ -47,7 +47,7 @@ func (s wrappedStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 
 func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res driver.Result, err error) {
 	wrappedParent := wrappedParentStmt{Stmt: s.parent}
-	res, err = s.intr.StmtExecContext(ctx, wrappedParent, s.query, args)
+	res, err = s.intr.StmtExecContext(ctx, wrappedParent, args)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 
 func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
 	wrappedParent := wrappedParentStmt{Stmt: s.parent}
-	rows, err = s.intr.StmtQueryContext(ctx, wrappedParent, s.query, args)
+	rows, err = s.intr.StmtQueryContext(ctx, wrappedParent, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The middleware was storing the query that was passed to PrepareContext
in the wrapped Stmt and then passing it to StmtExecContext and
StmtQueryContext.

Remove the query argument.
It is a remaining of the instrumentedsql pkg, were the query was stored
and passed to annotate tracing spans with it.

Removing it has the advantage that the interface is more close to the db
object interface of the stdlib. The string parameter was also
undocumented in the interface, it was only possible to figure out what
it is by reading the source code.

If the user needs to forward custom data he can wrap Rows, Stmt, Tx on
his own or better the middleware can provide in the future a mechanism
to forward arbitrary user defined data between those calls.

---

Analogous to https://github.com/ngrok/sqlmw/pull/14 