### PR TITLE
stmt: export WrappedParentStmt to allow Stmt wrapping in interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,9 @@ Go versions 1.9 and forward are supported.
 ## Fork
 
 This project began by forking the code in github.com/luna-duclos/instrumentedsql, which itself is a fork of github.com/ExpansiveWorlds/instrumentedsql
+
+## Project Status
+
+sqlmw is an early stage. \
+A version that guarantees API compatibility has not been released yet. \
+Breaking API changes can happen anytime in the master branch.

--- a/README.md
+++ b/README.md
@@ -154,3 +154,11 @@ This project began by forking the code in github.com/luna-duclos/instrumentedsql
 sqlmw is an early stage. \
 A version that guarantees API compatibility has not been released yet. \
 Breaking API changes can happen anytime in the master branch.
+
+## Breaking Changes
+
+- unversioned -> 0.1.0
+  - `StmtExecContext`, `StmtQueryContext`, `StmtClose` Interceptor methods now
+	accepts a parameter of type `sqlmw.Stmt` instead of
+	`driver.Stmt`, change the parameter type of your `Interceptor`
+	implementations accordingly

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ driver in any function that you override, like so:
             }
     }
 
+### Forwarding Data to method calls on Stmt, Tx, Rows
+
+See [interceptor_wrapping_example_test.go](interceptor_wrapping_example_test.go)
 
 ## Comparison with similar projects
 

--- a/interceptor.go
+++ b/interceptor.go
@@ -25,9 +25,9 @@ type Interceptor interface {
 	RowsClose(context.Context, driver.Rows) error
 
 	// Stmt interceptors
-	StmtExecContext(context.Context, driver.StmtExecContext, string, []driver.NamedValue) (driver.Result, error)
-	StmtQueryContext(context.Context, driver.StmtQueryContext, string, []driver.NamedValue) (driver.Rows, error)
-	StmtClose(context.Context, driver.Stmt) error
+	StmtExecContext(context.Context, *Stmt, string, []driver.NamedValue) (driver.Result, error)
+	StmtQueryContext(context.Context, *Stmt, string, []driver.NamedValue) (driver.Rows, error)
+	StmtClose(context.Context, *Stmt) error
 
 	// Tx interceptors
 	TxCommit(context.Context, driver.Tx) error
@@ -81,15 +81,15 @@ func (NullInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
 	return rows.Close()
 }
 
-func (NullInterceptor) StmtExecContext(ctx context.Context, stmt driver.StmtExecContext, _ string, args []driver.NamedValue) (driver.Result, error) {
+func (NullInterceptor) StmtExecContext(ctx context.Context, stmt *Stmt, _ string, args []driver.NamedValue) (driver.Result, error) {
 	return stmt.ExecContext(ctx, args)
 }
 
-func (NullInterceptor) StmtQueryContext(ctx context.Context, stmt driver.StmtQueryContext, _ string, args []driver.NamedValue) (driver.Rows, error) {
+func (NullInterceptor) StmtQueryContext(ctx context.Context, stmt *Stmt, _ string, args []driver.NamedValue) (driver.Rows, error) {
 	return stmt.QueryContext(ctx, args)
 }
 
-func (NullInterceptor) StmtClose(ctx context.Context, stmt driver.Stmt) error {
+func (NullInterceptor) StmtClose(ctx context.Context, stmt *Stmt) error {
 	return stmt.Close()
 }
 

--- a/interceptor_wrapping_example_test.go
+++ b/interceptor_wrapping_example_test.go
@@ -1,0 +1,47 @@
+package sqlmw_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"time"
+
+	"github.com/ngrok/sqlmw"
+)
+
+type MyInterceptor struct {
+	sqlmw.NullInterceptor
+}
+
+// MyStmt wraps a Stmt and annotates it with additional user-defined data.
+type MyStmt struct {
+	driver.Stmt
+	startTime time.Time
+	query     string
+}
+
+func (m *MyInterceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnPrepareContext, query string) (driver.Stmt, error) {
+	stmt, err := conn.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	// wrap the original Stmt and store additional a query string and a
+	// timestamp
+	return &MyStmt{Stmt: stmt, startTime: time.Now(), query: query}, nil
+}
+
+func (m *MyInterceptor) StmtQueryContext(ctx context.Context, stmt *sqlmw.Stmt, _ string, args []driver.NamedValue) (driver.Rows, error) {
+	// convert stmt to our StmtWithTs and access the data that we stored
+	// in the ConnPrepareContext() call.
+	if sq, ok := stmt.Parent().(*MyStmt); ok {
+		fmt.Printf("running StmtQueryContext for query: %s, start time: %s", sq.query, sq.startTime)
+	}
+
+	return stmt.QueryContext(ctx, args)
+}
+
+// Example demonstrates how data that is created in a ConnPrepareContext()
+// call can be made available on methods of a Stmt.
+// This work analagous for Rows and Tx objects.
+func Example() {}

--- a/stmt_go19_test.go
+++ b/stmt_go19_test.go
@@ -1,7 +1,11 @@
 package sqlmw
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -153,5 +157,116 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 				t.Errorf("cc mismatch.\n got: %#v\nwant: %#v", cc, test.expected.cc)
 			}
 		})
+	}
+}
+
+type userWrappedStmt struct {
+	driver.Stmt
+	userData bool
+}
+
+type wrapStmtInterceptor struct {
+	NullInterceptor
+}
+
+func (wrapStmtInterceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnPrepareContext, query string) (driver.Stmt, error) {
+	stmt, err := conn.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return &userWrappedStmt{Stmt: stmt, userData: true}, nil
+}
+
+func (wrapStmtInterceptor) StmtExecContext(ctx context.Context, stmt *Stmt, _ string, args []driver.NamedValue) (driver.Result, error) {
+	ud, ok := stmt.Parent().(*userWrappedStmt)
+	if !ok {
+		return nil, fmt.Errorf("stmt.Parent() has type %t, expected *userWrappedStmt", stmt.Parent())
+	}
+
+	if ud == nil {
+		return nil, errors.New("userData is nil")
+	}
+
+	if !ud.userData {
+		return nil, errors.New("userData is false, expected true")
+	}
+
+	return stmt.ExecContext(ctx, args)
+}
+
+func (wrapStmtInterceptor) StmtQueryContext(ctx context.Context, stmt *Stmt, _ string, args []driver.NamedValue) (driver.Rows, error) {
+	ud, ok := stmt.Parent().(*userWrappedStmt)
+	if !ok {
+		return nil, fmt.Errorf("stmt.Parent() has type %t, expected *userWrappedStmt", stmt.Parent())
+	}
+
+	if ud == nil {
+		return nil, errors.New("userData is nil")
+	}
+
+	if !ud.userData {
+		return nil, errors.New("userData is false, expected true")
+	}
+
+	return stmt.QueryContext(ctx, args)
+}
+
+func (wrapStmtInterceptor) StmtClose(ctx context.Context, stmt *Stmt) error {
+	ud, ok := stmt.Parent().(*userWrappedStmt)
+	if !ok {
+		return fmt.Errorf("stmt.Parent() has type %t, expected *userWrappedStmt", stmt.Parent())
+	}
+
+	if ud == nil {
+		return errors.New("userData is nil")
+	}
+
+	if !ud.userData {
+		return errors.New("userData is false, expected true")
+	}
+
+	return stmt.Close()
+}
+
+func TestWrapStmt(t *testing.T) {
+	driverNameWithSQLmw := t.Name() + "sqlmw"
+
+	fakeStmt := fakeStmt{}
+	sql.Register(
+		driverNameWithSQLmw,
+		Driver(&fakeDriver{conn: &fakeConn{stmt: &fakeStmt}}, &wrapStmtInterceptor{}),
+	)
+
+	db, err := sql.Open(driverNameWithSQLmw, "")
+	if err != nil {
+		t.Fatalf("Failed to open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Failed to close db: %v", err)
+		}
+	})
+
+	stmt, err := db.Prepare("")
+	if err != nil {
+		t.Fatalf("Prepare failed: %s", err)
+	}
+
+	if _, err := stmt.ExecContext(context.Background(), ""); err != nil {
+		t.Errorf("stmt.ExecContext failed: %s", err)
+	}
+
+	if _, err := stmt.Exec(""); err != nil {
+		t.Errorf("stmt.Exec failed: %s", err)
+	}
+
+	if _, err := stmt.QueryContext(context.Background(), ""); err != nil {
+		t.Errorf("stmt.QueryContext failed: %s", err)
+	}
+
+	if _, err := stmt.Query(""); err != nil {
+		t.Errorf("stmt.Query failed: %s", err)
 	}
 }


### PR DESCRIPTION
        stmt: export WrappedParentStmt to allow Stmt wrapping in interceptors

        In some scenarios it is required to annotate Stmt, Rows and Tx objects
        with additional data in an interceptor.
        Usecases can be:
        - relating a PrepareContext() call with operations on the Stmt in
          traces,
        - forwarding the query string passed to PrepareContext() to methods of
          the Stmt

        For Rows and Tx objects it is possible in an interceptor by creating a
        struct that wraps the original objects and has additional user-defined
        fields.
        The user-wrapped object is passed to the RowsNext, RowsClose, TxCommit
        and TxRollback interceptor methods. In those a type-conversion can be
        done and the user-defined data accessed.

        For Stmt objects this worked only for the StmtClose call.
        When the StmtQueryContext StmtExecContext methods of the interceptor
        were called, the driver.Stmt that was passed as parameter was wrapped
        into the private wrappedStmt struct by sqlmw.
        Because it was private, an interceptor implementation could not convert
        the Stmt parameter type and access it's own wrapped Stmt.

        This commit allows also to wrap Stmts in an interceptor and annotate it
        with additional data.
        This is done by making WrappedParentStmt public and changing the
        interceptor interface to  pass stmt of this type.
        Additionally:
        - wrappedParentStmt is renamed to Stmt,
        - a Stmt.Parent() helper method is added,
        - a testcase and example is added


This resolves https://github.com/ngrok/sqlmw/issues/10