### PR TITLE
rows: Support all optional interfaces for driver.Rows

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -94,7 +94,7 @@ func (c wrappedConn) Query(query string, args []driver.Value) (driver.Rows, erro
 		if err != nil {
 			return nil, err
 		}
-		return wrappedRows{intr: c.intr, parent: rows}, nil
+		return wrapRows(nil, c.intr, rows), nil //nolint
 	}
 	return nil, driver.ErrSkip
 }
@@ -113,7 +113,7 @@ func (c wrappedConn) QueryContext(ctx context.Context, query string, args []driv
 		return nil, err
 	}
 
-	return wrappedRows{intr: c.intr, ctx: ctx, parent: rows}, nil
+	return wrapRows(ctx, c.intr, rows), nil
 }
 
 type wrappedParentConn struct {

--- a/conn.go
+++ b/conn.go
@@ -94,7 +94,7 @@ func (c wrappedConn) Query(query string, args []driver.Value) (driver.Rows, erro
 		if err != nil {
 			return nil, err
 		}
-		return wrapRows(nil, c.intr, rows), nil //nolint
+		return wrapRows(context.Background(), c.intr, rows), nil //nolint
 	}
 	return nil, driver.ErrSkip
 }

--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -3,6 +3,9 @@ package sqlmw
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
+	"io"
+	"reflect"
 )
 
 type fakeDriver struct {
@@ -14,6 +17,7 @@ func (d *fakeDriver) Open(_ string) (driver.Conn, error) {
 }
 
 type fakeStmt struct {
+	rows   driver.Rows
 	called bool // nolint:structcheck // ignore unused warning, it is accessed via reflection
 }
 
@@ -23,16 +27,6 @@ type fakeStmtWithCheckNamedValue struct {
 
 type fakeStmtWithoutCheckNamedValue struct {
 	fakeStmt
-}
-
-type fakeStmtWithValStore struct {
-	fakeStmt
-	val []driver.Value
-}
-
-func (s *fakeStmtWithValStore) Query(v []driver.Value) (driver.Rows, error) {
-	s.val = v
-	return nil, nil
 }
 
 func (s fakeStmt) Close() error {
@@ -48,7 +42,7 @@ func (s fakeStmt) Exec(_ []driver.Value) (driver.Result, error) {
 }
 
 func (s fakeStmt) Query(_ []driver.Value) (driver.Rows, error) {
-	return nil, nil
+	return s.rows, nil
 }
 
 func (s *fakeStmtWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err error) {
@@ -58,20 +52,124 @@ func (s *fakeStmtWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err
 
 type fakeRows struct {
 	con         *fakeConn
+	vals        [][]driver.Value
 	closeCalled bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+	nextCalled  bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
 }
 
 func (r *fakeRows) Close() error {
 	r.con.rowsCloseCalled = true
+	r.closeCalled = true
 	return nil
 }
 
 func (r *fakeRows) Columns() []string {
+	if len(r.vals) == 0 {
+		return nil
+	}
+
+	var cols []string
+	for i := range r.vals[0] {
+		cols = append(cols, fmt.Sprintf("col%d", i))
+	}
+	return cols
+}
+
+func (r *fakeRows) Next(dest []driver.Value) error {
+	r.nextCalled = true
+	if len(r.vals) == 0 {
+		return io.EOF
+	}
+	copy(dest, r.vals[0])
+	r.vals = r.vals[1:]
 	return nil
 }
 
-func (r *fakeRows) Next(_ []driver.Value) error {
+type fakeWithRowsNextResultSet struct {
+	hasNextResultSetCalled bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+	nextResultSetCalled    bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+}
+
+func (f *fakeWithRowsNextResultSet) HasNextResultSet() bool {
+	f.hasNextResultSetCalled = true
+	return false
+}
+
+func (f *fakeWithRowsNextResultSet) NextResultSet() error {
+	f.nextResultSetCalled = true
 	return nil
+}
+
+type fakeWithColumnTypeDatabaseName struct {
+	columnTypeDatabaseNameCalled bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+}
+
+func (f *fakeWithColumnTypeDatabaseName) ColumnTypeDatabaseTypeName(i int) string {
+	f.columnTypeDatabaseNameCalled = true
+	return "sometype"
+}
+
+type fakeWithColumnTypeLength struct {
+	columnTypeLengthCalled bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+}
+
+func (f *fakeWithColumnTypeLength) ColumnTypeLength(index int) (length int64, ok bool) {
+	f.columnTypeLengthCalled = true
+	return 4, true
+}
+
+type fakeWithColumnTypePrecisionScale struct {
+	columnTypePrecisionScaleCalled bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+}
+
+func (f *fakeWithColumnTypePrecisionScale) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
+	f.columnTypePrecisionScaleCalled = true
+	return 0, 0, false
+}
+
+type fakeWithColumnTypeNullable struct {
+	columnTypeNullable bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+}
+
+func (f *fakeWithColumnTypeNullable) ColumnTypeNullable(i int) (nullable, ok bool) {
+	f.columnTypeNullable = true
+	return false, true
+}
+
+type fakeWithColumnTypeScanType struct {
+	columnTypeScanTypeCalled bool // nolint:structcheck,unused // ignore unused warning, it is accessed via reflection
+}
+
+func (f *fakeWithColumnTypeScanType) ColumnTypeScanType(i int) reflect.Type {
+	f.columnTypeScanTypeCalled = true
+	return reflect.TypeOf("")
+}
+
+type fakeRowsLikeMysql struct {
+	fakeRows
+	fakeWithRowsNextResultSet
+	fakeWithColumnTypeDatabaseName
+	fakeWithColumnTypePrecisionScale
+	fakeWithColumnTypeNullable
+	fakeWithColumnTypeScanType
+}
+
+type fakeRowsLikePgx struct {
+	fakeRows
+	fakeWithColumnTypeDatabaseName
+	fakeWithColumnTypeLength
+	fakeWithColumnTypePrecisionScale
+	fakeWithColumnTypeNullable
+	fakeWithColumnTypeScanType
+}
+
+type fakeRowsLikeSqlite3 struct {
+	fakeRows
+	fakeWithColumnTypeDatabaseName
+	fakeWithColumnTypeLength
+	fakeWithColumnTypePrecisionScale
+	fakeWithColumnTypeNullable
+	fakeWithColumnTypeScanType
 }
 
 type fakeConn struct {
@@ -100,8 +198,17 @@ func (c *fakeConn) Close() error { return nil }
 
 func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
 
-func (c *fakeConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
-	return &fakeRows{con: c}, nil
+func (c *fakeConn) QueryContext(_ context.Context, _ string, nvs []driver.NamedValue) (driver.Rows, error) {
+	if c.stmt == nil {
+		return &fakeRows{con: c}, nil
+	}
+
+	var args []driver.Value
+	for _, nv := range nvs {
+		args = append(args, nv.Value)
+	}
+
+	return c.stmt.Query(args)
 }
 
 func (c *fakeConnWithCheckNamedValue) CheckNamedValue(_ *driver.NamedValue) (err error) {

--- a/rows.go
+++ b/rows.go
@@ -3,17 +3,14 @@ package sqlmw
 import (
 	"context"
 	"database/sql/driver"
+	"reflect"
 )
+
+//go:generate go run ./tools/rows_picker_gen.go -o rows_picker.go
 
 // Compile time validation that our types implement the expected interfaces
 var (
-	_ driver.Rows                           = wrappedRows{}
-	_ driver.RowsColumnTypeDatabaseTypeName // TODO
-	_ driver.RowsColumnTypeLength           // TODO
-	_ driver.RowsColumnTypeNullable         // TODO
-	_ driver.RowsColumnTypePrecisionScale   // TODO
-	_ driver.RowsColumnTypeScanType         // TODO
-	_ driver.RowsNextResultSet              // TODO
+	_ driver.Rows = wrappedRows{}
 )
 
 type wrappedRows struct {
@@ -32,4 +29,56 @@ func (r wrappedRows) Close() error {
 
 func (r wrappedRows) Next(dest []driver.Value) (err error) {
 	return r.intr.RowsNext(r.ctx, r.parent, dest)
+}
+
+type wrappedRowsNextResultSet struct {
+	rows driver.Rows
+}
+
+func (r wrappedRowsNextResultSet) HasNextResultSet() bool {
+	return r.rows.(driver.RowsNextResultSet).HasNextResultSet()
+}
+
+func (r wrappedRowsNextResultSet) NextResultSet() error {
+	return r.rows.(driver.RowsNextResultSet).NextResultSet()
+}
+
+type wrappedRowsColumnTypeDatabaseTypeName struct {
+	rows driver.Rows
+}
+
+func (r wrappedRowsColumnTypeDatabaseTypeName) ColumnTypeDatabaseTypeName(index int) string {
+	return r.rows.(driver.RowsColumnTypeDatabaseTypeName).ColumnTypeDatabaseTypeName(index)
+}
+
+type wrappedRowsColumnTypeLength struct {
+	rows driver.Rows
+}
+
+func (r wrappedRowsColumnTypeLength) ColumnTypeLength(index int) (length int64, ok bool) {
+	return r.rows.(driver.RowsColumnTypeLength).ColumnTypeLength(index)
+}
+
+type wrappedRowsColumnTypeNullable struct {
+	rows driver.Rows
+}
+
+func (r wrappedRowsColumnTypeNullable) ColumnTypeNullable(index int) (nullable, ok bool) {
+	return r.rows.(driver.RowsColumnTypeNullable).ColumnTypeNullable(index)
+}
+
+type wrappedRowsColumnTypePrecisionScale struct {
+	rows driver.Rows
+}
+
+func (r wrappedRowsColumnTypePrecisionScale) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
+	return r.rows.(driver.RowsColumnTypePrecisionScale).ColumnTypePrecisionScale(index)
+}
+
+type wrappedRowsColumnTypeScanType struct {
+	rows driver.Rows
+}
+
+func (r wrappedRowsColumnTypeScanType) ColumnTypeScanType(index int) reflect.Type {
+	return r.rows.(driver.RowsColumnTypeScanType).ColumnTypeScanType(index)
 }

--- a/rows.go
+++ b/rows.go
@@ -13,6 +13,22 @@ var (
 	_ driver.Rows = wrappedRows{}
 )
 
+// RowsUnwrapper must be used by any middleware that provides its own wrapping
+// for driver.Rows. RowsUnwrap should return the original driver.Rows the
+// middleware received. The result of RowsUnwrap is repeatedly unwrapped
+// until the result no longer implements the interface (this should be
+// the driver.Rows from the original database/sql driver). sqlmw will then
+// pass a type that matches the optional interface set of the driver.Rows
+// implementation of the original driver.
+//
+// If a middleware returns a custom driver.Rows, the custom implmentation
+// must support all the driver.Rows optional interfaces that are supported by
+// by the drivers that will be used with it. To support any arbitrary driver
+// all the optional methods must be supported.
+type RowsUnwrapper interface {
+	RowsUnwrap() driver.Rows
+}
+
 type wrappedRows struct {
 	intr   Interceptor
 	ctx    context.Context

--- a/rows.go
+++ b/rows.go
@@ -8,11 +8,6 @@ import (
 
 //go:generate go run ./tools/rows_picker_gen.go -o rows_picker.go
 
-// Compile time validation that our types implement the expected interfaces
-var (
-	_ driver.Rows = wrappedRows{}
-)
-
 // RowsUnwrapper must be used by any middleware that provides its own wrapping
 // for driver.Rows. Unwrap should return the original driver.Rows the
 // middleware received. You may wish to wrap the driver.Rows returned by the

--- a/rows.go
+++ b/rows.go
@@ -26,7 +26,7 @@ var (
 // by the drivers that will be used with it. To support any arbitrary driver
 // all the optional methods must be supported.
 type RowsUnwrapper interface {
-	RowsUnwrap() driver.Rows
+	Unwrap() driver.Rows
 }
 
 type wrappedRows struct {

--- a/rows.go
+++ b/rows.go
@@ -14,12 +14,14 @@ var (
 )
 
 // RowsUnwrapper must be used by any middleware that provides its own wrapping
-// for driver.Rows. RowsUnwrap should return the original driver.Rows the
-// middleware received. The result of RowsUnwrap is repeatedly unwrapped
-// until the result no longer implements the interface (this should be
-// the driver.Rows from the original database/sql driver). sqlmw will then
-// pass a type that matches the optional interface set of the driver.Rows
-// implementation of the original driver.
+// for driver.Rows. Unwrap should return the original driver.Rows the
+// middleware received. You may wish to wrap the driver.Rows returned by the
+// Query methods if you want to pass extra information from the Query call to
+// the subsequent RowsNext and RowsClose calls.
+//
+// sqlmw needs to retrieve the original driver.Rows in order to determine the
+// original set of optional methods supported by the driver.Rows of the
+// database driver in use by the caller.
 //
 // If a middleware returns a custom driver.Rows, the custom implmentation
 // must support all the driver.Rows optional interfaces that are supported by

--- a/rows_picker.go
+++ b/rows_picker.go
@@ -1,3 +1,6 @@
+// Code generated using tool/rows_picker_gen.go DO NOT EDIT.
+// Date: Dec  2 16:24:25
+
 package sqlmw
 
 import (
@@ -975,9 +978,6 @@ func init() {
 	}
 }
 
-type RowsUnwrapper interface {
-	RowsUnwrap() driver.Rows
-}
 
 func wrapRows(ctx context.Context, intr Interceptor, r driver.Rows) driver.Rows {
 	or := r

--- a/rows_picker.go
+++ b/rows_picker.go
@@ -978,15 +978,14 @@ func init() {
 	}
 }
 
-
 func wrapRows(ctx context.Context, intr Interceptor, r driver.Rows) driver.Rows {
 	or := r
 	for {
 		ur, ok := or.(RowsUnwrapper)
 		if !ok {
-		  break
+			break
 		}
-		or = ur.RowsUnwrap()
+		or = ur.Unwrap()
 	}
 
 	id := 0

--- a/rows_picker.go
+++ b/rows_picker.go
@@ -1,0 +1,1018 @@
+package sqlmw
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+const (
+	rowsNextResultSet = 1 << iota
+	rowsColumnTypeDatabaseTypeName
+	rowsColumnTypeLength
+	rowsColumnTypeNullable
+	rowsColumnTypePrecisionScale
+	rowsColumnTypeScanType
+)
+
+var pickRows = make([]func(*wrappedRows) driver.Rows, 64)
+
+func init() {
+
+	// plain driver.Rows
+	pickRows[0] = func(r *wrappedRows) driver.Rows {
+		return r
+	}
+
+	// plain driver.Rows
+	pickRows[1] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[2] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[3] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[4] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[5] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[6] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[7] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[8] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[9] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[10] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[11] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[12] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[13] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[14] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[15] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[16] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[17] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[18] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[19] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[20] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[21] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[22] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[23] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[24] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[25] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[26] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[27] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[28] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[29] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[30] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[31] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[32] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[33] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[34] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[35] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[36] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[37] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[38] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[39] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[40] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[41] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[42] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[43] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[44] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[45] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[46] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[47] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[48] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[49] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[50] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[51] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[52] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[53] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[54] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[55] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[56] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[57] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[58] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[59] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[60] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[61] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[62] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+
+	// plain driver.Rows
+	pickRows[63] = func(r *wrappedRows) driver.Rows {
+		return struct {
+			*wrappedRows
+			wrappedRowsNextResultSet
+			wrappedRowsColumnTypeDatabaseTypeName
+			wrappedRowsColumnTypeLength
+			wrappedRowsColumnTypeNullable
+			wrappedRowsColumnTypePrecisionScale
+			wrappedRowsColumnTypeScanType
+		}{
+			r,
+			wrappedRowsNextResultSet{r.parent},
+			wrappedRowsColumnTypeDatabaseTypeName{r.parent},
+			wrappedRowsColumnTypeLength{r.parent},
+			wrappedRowsColumnTypeNullable{r.parent},
+			wrappedRowsColumnTypePrecisionScale{r.parent},
+			wrappedRowsColumnTypeScanType{r.parent},
+		}
+	}
+}
+
+type RowsUnwrapper interface {
+	RowsUnwrap() driver.Rows
+}
+
+func wrapRows(ctx context.Context, intr Interceptor, r driver.Rows) driver.Rows {
+	or := r
+	for {
+		ur, ok := or.(RowsUnwrapper)
+		if !ok {
+		  break
+		}
+		or = ur.RowsUnwrap()
+	}
+
+	id := 0
+
+	if _, ok := or.(driver.RowsNextResultSet); ok {
+		id += rowsNextResultSet
+	}
+	if _, ok := or.(driver.RowsColumnTypeDatabaseTypeName); ok {
+		id += rowsColumnTypeDatabaseTypeName
+	}
+	if _, ok := or.(driver.RowsColumnTypeLength); ok {
+		id += rowsColumnTypeLength
+	}
+	if _, ok := or.(driver.RowsColumnTypeNullable); ok {
+		id += rowsColumnTypeNullable
+	}
+	if _, ok := or.(driver.RowsColumnTypePrecisionScale); ok {
+		id += rowsColumnTypePrecisionScale
+	}
+	if _, ok := or.(driver.RowsColumnTypeScanType); ok {
+		id += rowsColumnTypeScanType
+	}
+	wr := &wrappedRows{
+		ctx:    ctx,
+		intr:   intr,
+		parent: r,
+	}
+	return pickRows[id](wr)
+}

--- a/rows_test.go
+++ b/rows_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"log"
+	"reflect"
 	"testing"
 )
 
@@ -162,5 +163,199 @@ func TestRowsNext(t *testing.T) {
 
 	if ctxVal != vStr {
 		t.Errorf("ctx is different, value for key: %s, is %q, expected %q", ctxKey, vStr, ctxVal)
+	}
+}
+
+func TestRows_LikePGX(t *testing.T) {
+	strType := reflect.TypeOf("")
+	con := &fakeConn{}
+	rs := fakeRows{vals: [][]driver.Value{{"hello", "world"}}, con: con}
+	rows := &fakeRowsLikePgx{
+		fakeRows:                       rs,
+		fakeWithColumnTypeDatabaseName: fakeWithColumnTypeDatabaseName{r: &rs, names: []string{"CUSTOMVARCHAR", "CUSTOMVARCHAR"}},
+		fakeWithColumnTypeScanType:     fakeWithColumnTypeScanType{r: &rs, scanTypes: []reflect.Type{strType, strType}},
+		fakeWithColumnTypeNullable:     fakeWithColumnTypeNullable{r: &rs, nullables: []bool{false, false}, oks: []bool{true, true}},
+		fakeWithColumnTypeLength:       fakeWithColumnTypeLength{r: &rs, lengths: []int64{5, 5}, bools: []bool{true, true}},
+		fakeWithColumnTypePrecisionScale: fakeWithColumnTypePrecisionScale{
+			r:          &rs,
+			precisions: []int64{0, 0},
+			scales:     []int64{0, 0},
+			bools:      []bool{false, false},
+		},
+	}
+
+	stmt := fakeStmt{
+		rows: rows,
+	}
+	con.stmt = stmt
+	driverName := t.Name()
+	interceptor := rowsNextInterceptor{}
+
+	sql.Register(
+		driverName,
+		Driver(&fakeDriver{conn: con}, &interceptor),
+	)
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("opening db failed: %s", err)
+	}
+
+	ctx := context.Background()
+	ctxKey := "ctxkey"
+	ctxVal := "1"
+
+	ctx = context.WithValue(ctx, ctxKey, ctxVal) // nolint: staticcheck // not using a custom type for the ctx key is not an issue here
+
+	qrs, err := db.QueryContext(ctx, "", "")
+	if err != nil {
+		t.Fatalf("db.Query failed: %s", err)
+	}
+
+	names, err := qrs.Columns()
+	if err != nil {
+		t.Errorf("error calling Columns, %v", err)
+	}
+
+	cts, err := qrs.ColumnTypes()
+	if err != nil {
+		t.Errorf("error calling ColumnTypes, %v", err)
+	}
+
+	if len(names) != 2 || len(names) != len(cts) {
+		t.Errorf("wrong column name or types count")
+	}
+
+	// There's no real way these can be called, but we'll text incase the
+	// test implementation changes
+	if rs.hasNextResultSetCalled {
+		t.Errorf("HasNextResultSetCalled, on non-supporting type, %v", err)
+	}
+	if rs.nextResultSetCalled {
+		t.Errorf("NextResultSetCalled, on non-supporting type, %v", err)
+	}
+
+	if !rs.columnTypeDatabaseNameCalled {
+		t.Errorf("ColumnTypeDatabaseName not called, %v", err)
+	}
+
+	if !rs.columnTypeLengthCalled {
+		t.Errorf("ColumnTypeTypeLenght not called, %v", err)
+	}
+
+	if !rs.columnTypeNullable {
+		t.Errorf("ColumnTypeTypeLenght not called, %v", err)
+	}
+
+	if !rs.columnTypePrecisionScaleCalled {
+		t.Errorf("ColumnTypePrecisionScale not called, %v", err)
+	}
+
+	var id, name string
+	for qrs.Next() {
+		err := qrs.Scan(&id, &name)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	err = qrs.Close()
+	if err != nil {
+		t.Errorf("rows Close failed: %s", err)
+	}
+
+	if !rows.nextCalled {
+		t.Error("driver rows.Next was not called")
+	}
+
+	if !interceptor.rowsNextCalled {
+		t.Error("interceptor rows.Next was not called")
+	}
+
+	if !interceptor.rowsNextCalled {
+		t.Error("interceptor rows.Next was not called")
+	}
+
+	if interceptor.rowsNextLastCtx == nil {
+		t.Fatal("rows close ctx is nil")
+	}
+
+	v := interceptor.rowsNextLastCtx.Value(ctxKey)
+	if v == nil {
+		t.Fatalf("ctx is different, missing value for key: %s", ctxKey)
+	}
+
+	vStr, ok := v.(string)
+	if !ok {
+		t.Fatalf("ctx is different, value for key: %s, has type %t, expected string", ctxKey, v)
+	}
+
+	if ctxVal != vStr {
+		t.Errorf("ctx is different, value for key: %s, is %q, expected %q", ctxKey, vStr, ctxVal)
+	}
+}
+
+func TestWrapRows(t *testing.T) {
+	ctx := context.Background()
+	tt := []struct {
+		name string
+		rows driver.Rows
+	}{
+		{
+			name: "vanilla",
+			rows: &fakeRows{},
+		},
+		{
+			name: "pgx",
+			rows: &fakeRowsLikePgx{},
+		},
+		{
+			name: "mysql",
+			rows: &fakeRowsLikeMysql{},
+		},
+	}
+
+	for _, st := range tt {
+		st := st
+		t.Run(st.name, func(t *testing.T) {
+			rows := st.rows
+			wr := wrapRows(ctx, nil, rows)
+
+			_, rok := rows.(driver.RowsNextResultSet)
+			_, wok := wr.(driver.RowsNextResultSet)
+			if rok != wok {
+				t.Fatalf("inconsinstent support for driver.RowsNextResultSet")
+			}
+
+			_, rok = rows.(driver.RowsColumnTypeDatabaseTypeName)
+			_, wok = wr.(driver.RowsColumnTypeDatabaseTypeName)
+			if rok != wok {
+				t.Fatalf("inconsinstent support for driver.RowsColumnTypeDatabaseTypeName")
+			}
+
+			_, rok = rows.(driver.RowsColumnTypeLength)
+			_, wok = wr.(driver.RowsColumnTypeLength)
+			if rok != wok {
+				t.Fatalf("inconsinstent support for driver.RowsColumnTypeLength")
+			}
+
+			_, rok = rows.(driver.RowsColumnTypeNullable)
+			_, wok = wr.(driver.RowsColumnTypeNullable)
+			if rok != wok {
+				t.Fatalf("inconsinstent support for driver.RowsColumnTypeNullable")
+			}
+
+			_, rok = rows.(driver.RowsColumnTypeScanType)
+			_, wok = wr.(driver.RowsColumnTypeScanType)
+			if rok != wok {
+				t.Fatalf("inconsinstent support for driver.RowsColumnTypeScanType")
+			}
+
+			_, rok = rows.(driver.RowsColumnTypePrecisionScale)
+			_, wok = wr.(driver.RowsColumnTypePrecisionScale)
+			if rok != wok {
+				t.Fatalf("inconsinstent support for driver.RowsColumnTypePrecisionScale")
+			}
+		})
 	}
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -126,7 +126,7 @@ func TestRowsNext(t *testing.T) {
 	for rs.Next() {
 		err := rs.Scan(&id, &name)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 
@@ -255,7 +255,7 @@ func TestRows_LikePGX(t *testing.T) {
 	for qrs.Next() {
 		err := qrs.Scan(&id, &name)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 
@@ -324,7 +324,7 @@ func TestWrapRows(t *testing.T) {
 			_, rok := rows.(driver.RowsNextResultSet)
 			_, wok := wr.(driver.RowsNextResultSet)
 			if rok != wok {
-				t.Fatalf("inconsinstent support for driver.RowsNextResultSet")
+				t.Fatalf("inconsistent support for driver.RowsNextResultSet")
 			}
 
 			_, rok = rows.(driver.RowsColumnTypeDatabaseTypeName)

--- a/rows_test.go
+++ b/rows_test.go
@@ -226,7 +226,7 @@ func TestRows_LikePGX(t *testing.T) {
 		t.Errorf("wrong column name or types count")
 	}
 
-	// There's no real way these can be called, but we'll text incase the
+	// There's no real way these can be called, but we'll test in case the
 	// test implementation changes
 	if rs.hasNextResultSetCalled {
 		t.Errorf("HasNextResultSetCalled, on non-supporting type, %v", err)

--- a/rows_test.go
+++ b/rows_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"log"
 	"testing"
 )
 
@@ -73,5 +74,93 @@ func TestRowsClose(t *testing.T) {
 
 	if !con.rowsCloseCalled {
 		t.Fatalf("rows close of driver was not called")
+	}
+}
+
+type rowsNextInterceptor struct {
+	NullInterceptor
+
+	rowsNextCalled  bool
+	rowsNextLastCtx context.Context
+}
+
+func (r *rowsNextInterceptor) RowsNext(ctx context.Context, rows driver.Rows, dest []driver.Value) error {
+	r.rowsNextCalled = true
+	r.rowsNextLastCtx = ctx
+	return rows.Next(dest)
+}
+
+func TestRowsNext(t *testing.T) {
+	con := &fakeConn{}
+	rows := &fakeRows{vals: [][]driver.Value{{"hello", "world"}}, con: con}
+	stmt := fakeStmt{
+		rows: rows,
+	}
+	con.stmt = stmt
+	driverName := t.Name()
+	interceptor := rowsNextInterceptor{}
+
+	sql.Register(
+		driverName,
+		Driver(&fakeDriver{conn: con}, &interceptor),
+	)
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("opening db failed: %s", err)
+	}
+
+	ctx := context.Background()
+	ctxKey := "ctxkey"
+	ctxVal := "1"
+
+	ctx = context.WithValue(ctx, ctxKey, ctxVal) // nolint: staticcheck // not using a custom type for the ctx key is not an issue here
+
+	rs, err := db.QueryContext(ctx, "", "")
+	if err != nil {
+		t.Fatalf("db.Query failed: %s", err)
+	}
+
+	var id, name string
+	for rs.Next() {
+		err := rs.Scan(&id, &name)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	err = rs.Close()
+	if err != nil {
+		t.Errorf("rows Close failed: %s", err)
+	}
+
+	if !rows.nextCalled {
+		t.Error("driver rows.Next was not called")
+	}
+
+	if !interceptor.rowsNextCalled {
+		t.Error("interceptor rows.Next was not called")
+	}
+
+	if !interceptor.rowsNextCalled {
+		t.Error("interceptor rows.Next was not called")
+	}
+
+	if interceptor.rowsNextLastCtx == nil {
+		t.Fatal("rows close ctx is nil")
+	}
+
+	v := interceptor.rowsNextLastCtx.Value(ctxKey)
+	if v == nil {
+		t.Fatalf("ctx is different, missing value for key: %s", ctxKey)
+	}
+
+	vStr, ok := v.(string)
+	if !ok {
+		t.Fatalf("ctx is different, value for key: %s, has type %t, expected string", ctxKey, v)
+	}
+
+	if ctxVal != vStr {
+		t.Errorf("ctx is different, value for key: %s, is %q, expected %q", ctxKey, vStr, ctxVal)
 	}
 }

--- a/stmt.go
+++ b/stmt.go
@@ -42,7 +42,7 @@ func (s wrappedStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return wrappedRows{intr: s.intr, ctx: s.ctx, parent: rows}, nil
+	return wrapRows(s.ctx, s.intr, rows), nil
 }
 
 func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res driver.Result, err error) {
@@ -60,7 +60,7 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	if err != nil {
 		return nil, err
 	}
-	return wrappedRows{intr: s.intr, ctx: ctx, parent: rows}, nil
+	return wrapRows(ctx, s.intr, rows), nil
 }
 
 func (s wrappedStmt) ColumnConverter(idx int) driver.ValueConverter {

--- a/stmt_go19_test.go
+++ b/stmt_go19_test.go
@@ -11,7 +11,7 @@ import (
 // driver.DefaultParameterConverter is used when neither stmt nor con
 // implements any value converters.
 func TestDefaultParameterConversion(t *testing.T) {
-	driverNameWithSQLmw := t.Name() + "sqlmw"
+	driverName := driverName(t)
 
 	expectVal := int64(1)
 	con := &fakeConn{}
@@ -24,11 +24,11 @@ func TestDefaultParameterConversion(t *testing.T) {
 	con.stmt = fakeStmt
 
 	sql.Register(
-		driverNameWithSQLmw,
+		driverName,
 		Driver(&fakeDriver{conn: con}, &NullInterceptor{}),
 	)
 
-	db, err := sql.Open(driverNameWithSQLmw, "")
+	db, err := sql.Open(driverName, "")
 	if err != nil {
 		t.Fatalf("Failed to open: %v", err)
 	}
@@ -134,8 +134,9 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			sql.Register("fake-driver:"+name, Driver(test.fd, &fakeInterceptor{}))
-			db, err := sql.Open("fake-driver:"+name, "dummy")
+			driverName := driverName(t)
+			sql.Register(driverName, Driver(test.fd, &fakeInterceptor{}))
+			db, err := sql.Open(driverName, "dummy")
 			if err != nil {
 				t.Errorf("Failed to open: %v", err)
 			}

--- a/stmt_go19_test.go
+++ b/stmt_go19_test.go
@@ -2,6 +2,7 @@ package sqlmw
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"reflect"
 	"testing"
 )
@@ -11,10 +12,20 @@ import (
 // implements any value converters.
 func TestDefaultParameterConversion(t *testing.T) {
 	driverNameWithSQLmw := t.Name() + "sqlmw"
-	fakeStmt := fakeStmtWithValStore{}
+
+	expectVal := int64(1)
+	con := &fakeConn{}
+	fakeStmt := &fakeStmt{
+		rows: &fakeRows{
+			con:  con,
+			vals: [][]driver.Value{{expectVal}},
+		},
+	}
+	con.stmt = fakeStmt
+
 	sql.Register(
 		driverNameWithSQLmw,
-		Driver(&fakeDriver{conn: &fakeConn{stmt: &fakeStmt}}, &NullInterceptor{}),
+		Driver(&fakeDriver{conn: con}, &NullInterceptor{}),
 	)
 
 	db, err := sql.Open(driverNameWithSQLmw, "")
@@ -36,24 +47,26 @@ func TestDefaultParameterConversion(t *testing.T) {
 	// int32 values are converted by driver.DefaultParameterConverter to
 	// int64
 	queryVal := int32(1)
-	_, err = stmt.Query(queryVal)
+	rows, err := stmt.Query(queryVal)
 	if err != nil {
 		t.Fatalf("Query failed: %s", err)
 	}
 
-	if len(fakeStmt.val) != 1 {
-		t.Fatalf("fakestmt got %d values, expected %d", len(fakeStmt.val), 1)
+	count := 0
+	for rows.Next() {
+		var v int64
+		err := rows.Scan(&v)
+		if err != nil {
+			t.Fatalf("rows.Scan failed, %v", err)
+		}
+		if v != 1 {
+			t.Errorf("converted value is %d, passed value to Query was: %d", v, expectVal)
+		}
+		count++
 	}
 
-	switch v := fakeStmt.val[0].(type) {
-	case int32:
-		t.Errorf("int32 was not converted to int64 **without** using sqlmw")
-	case int64:
-		if v != int64(1) {
-			t.Errorf("converted value is %d, passed value to Query was: %d", v, queryVal)
-		}
-	default:
-		t.Errorf("converted value has type %T, expected int64", fakeStmt.val[0])
+	if count != 1 {
+		t.Fatalf("got too many rows, expected 1, got %d ", 1)
 	}
 }
 

--- a/tools/rows_picker_gen.go
+++ b/tools/rows_picker_gen.go
@@ -23,7 +23,6 @@ func main() {
 			log.Fatalf("could not create file %q, %v", *fn, err)
 		}
 	}
-	defer out.Close()
 
 	intfs := []string{
 		"NextResultSet",
@@ -51,6 +50,11 @@ func main() {
 
 	fmt.Fprintln(out, "")
 	genWrapRows(out, intfs)
+
+	err = out.Close()
+	if err != nil {
+		log.Fatalf("could close file, %v", err)
+	}
 }
 
 func genComment(w io.Writer) {

--- a/tools/rows_picker_gen.go
+++ b/tools/rows_picker_gen.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package main
 
 import (
@@ -6,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"time"
 )
 
 func main() {
@@ -31,6 +34,7 @@ func main() {
 		"ColumnTypeScanType",
 	}
 
+	genComment(out)
 	fmt.Fprintln(out, "package sqlmw")
 
 	fmt.Fprintln(out, "")
@@ -49,16 +53,12 @@ func main() {
 	genWrapRows(out, intfs)
 }
 
-/*
-const (
-	rowsNextResultSet = 1 << iota
-	rowsColumnTypeDatabaseTypeName
-	rowsColumnTypeLength
-	rowsColumnTypeNullable
-	rowsColumnTypePrecisionScale
-	rowsColumnTypeScanType
-)
-*/
+func genComment(w io.Writer) {
+	str := time.Now().Format(time.Stamp)
+	fmt.Fprintln(w, "// Code generated using tool/rows_picker_gen.go DO NOT EDIT.")
+	fmt.Fprintf(w, "// Date: %s\n", str)
+	fmt.Fprintln(w, "")
+}
 
 func genConst(w io.Writer, intfs []string) {
 	fmt.Fprintln(w, "const (")
@@ -114,10 +114,6 @@ func genPickerTable(w io.Writer, intfs []string) {
 }
 
 func genWrapRows(w io.Writer, intfs []string) {
-	fmt.Fprintln(w, `type RowsUnwrapper interface {
-	RowsUnwrap() driver.Rows
-}`)
-
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "func wrapRows(ctx context.Context, intr Interceptor, r driver.Rows) driver.Rows {")
 	fmt.Fprintln(w, `	or := r


### PR DESCRIPTION
This uses some code generation to wrap an incoming rows in a type
that supports the exact set of interfaces that are supported by
the original type.