### PR TITLE
Allow interceptor to edit wrapped contexts

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -44,7 +44,7 @@ func (c wrappedConn) Begin() (driver.Tx, error) {
 
 func (c wrappedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {
 	wrappedParent := wrappedParentConn{c.parent}
-	tx, err = c.intr.ConnBeginTx(ctx, wrappedParent, opts)
+	ctx, tx, err = c.intr.ConnBeginTx(ctx, wrappedParent, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (c wrappedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx dri
 
 func (c wrappedConn) PrepareContext(ctx context.Context, query string) (stmt driver.Stmt, err error) {
 	wrappedParent := wrappedParentConn{c.parent}
-	stmt, err = c.intr.ConnPrepareContext(ctx, wrappedParent, query)
+	ctx, stmt, err = c.intr.ConnPrepareContext(ctx, wrappedParent, query)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (c wrappedConn) QueryContext(ctx context.Context, query string, args []driv
 	}
 
 	wrappedParent := wrappedParentConn{c.parent}
-	rows, err = c.intr.ConnQueryContext(ctx, wrappedParent, query, args)
+	ctx, rows, err = c.intr.ConnQueryContext(ctx, wrappedParent, query, args)
 	if err != nil {
 		return nil, err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,249 @@
+package sqlmw
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+)
+
+const (
+	connRowContextKey    = "context"
+	connRowContextValue  = "value"
+	connStmtContextKey   = "stmtcontext"
+	connStmtContextValue = "stmtvalue"
+	connTxContextKey     = "txcontext"
+	connTxContextValue   = "txvalue"
+)
+
+type connTestInterceptor struct {
+	T               *testing.T
+	RowsNextValid   bool
+	RowsCloseValid  bool
+	StmtCloseValid  bool
+	TxCommitValid   bool
+	TxRollbackValid bool
+	NullInterceptor
+}
+
+func (i *connTestInterceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnPrepareContext, query string) (context.Context, driver.Stmt, error) {
+	ctx = context.WithValue(ctx, connStmtContextKey, connStmtContextValue)
+
+	s, err := conn.PrepareContext(ctx, query)
+	return ctx, s, err
+}
+
+func (i *connTestInterceptor) ConnQueryContext(ctx context.Context, conn driver.QueryerContext, query string, args []driver.NamedValue) (context.Context, driver.Rows, error) {
+	ctx = context.WithValue(ctx, connRowContextKey, connRowContextValue)
+
+	r, err := conn.QueryContext(ctx, query, args)
+	return ctx, r, err
+}
+
+func (i *connTestInterceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx, txOpts driver.TxOptions) (context.Context, driver.Tx, error) {
+	ctx = context.WithValue(ctx, connTxContextKey, connTxContextValue)
+
+	t, err := conn.BeginTx(ctx, txOpts)
+	return ctx, t, err
+}
+
+func (i *connTestInterceptor) RowsNext(ctx context.Context, rows driver.Rows, dest []driver.Value) error {
+	if ctx.Value(connRowContextKey) == connRowContextValue {
+		i.RowsNextValid = true
+	}
+
+	return rows.Next(dest)
+}
+
+func (i *connTestInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
+	if ctx.Value(connRowContextKey) == connRowContextValue {
+		i.RowsCloseValid = true
+	}
+
+	return rows.Close()
+}
+
+func (i *connTestInterceptor) StmtClose(ctx context.Context, stmt driver.Stmt) error {
+	if ctx.Value(connStmtContextKey) == connStmtContextValue {
+		i.StmtCloseValid = true
+	}
+
+	i.T.Log(ctx)
+
+	return stmt.Close()
+}
+
+func (i *connTestInterceptor) TxCommit(ctx context.Context, tx driver.Tx) error {
+	if ctx.Value(connTxContextKey) == connTxContextValue {
+		i.TxCommitValid = true
+	}
+
+	i.T.Log(ctx)
+
+	return tx.Commit()
+}
+
+func (i *connTestInterceptor) TxRollback(ctx context.Context, tx driver.Tx) error {
+	if ctx.Value(connTxContextKey) == connTxContextValue {
+		i.TxRollbackValid = true
+	}
+
+	i.T.Log(ctx)
+
+	return tx.Rollback()
+}
+
+func TestConnQueryContext_PassWrappedRowContext(t *testing.T) {
+	driverName := driverName(t)
+
+	con := &fakeConn{}
+
+	ti := &connTestInterceptor{T: t}
+
+	sql.Register(
+		driverName,
+		Driver(&fakeDriver{conn: con}, ti),
+	)
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("Failed to open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Failed to close db: %v", err)
+		}
+	})
+
+	rows, err := db.QueryContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Prepare failed: %s", err)
+	}
+
+	rows.Next()
+	rows.Close()
+
+	if !ti.RowsCloseValid {
+		t.Error("RowsClose context not valid")
+	}
+	if !ti.RowsNextValid {
+		t.Error("RowsNext context not valid")
+	}
+}
+
+func TestConnPrepareContext_PassWrappedStmtContext(t *testing.T) {
+	driverName := driverName(t)
+
+	con := &fakeConn{}
+	fakeStmt := &fakeStmt{
+		rows: &fakeRows{
+			con:  con,
+			vals: [][]driver.Value{{}},
+		},
+	}
+	con.stmt = fakeStmt
+
+	ti := &connTestInterceptor{T: t}
+
+	sql.Register(
+		driverName,
+		Driver(&fakeDriver{conn: con}, ti),
+	)
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("Failed to open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Failed to close db: %v", err)
+		}
+	})
+
+	stmt, err := db.PrepareContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Prepare failed: %s", err)
+	}
+
+	stmt.Close()
+
+	if !ti.StmtCloseValid {
+		t.Error("StmtClose context not valid")
+	}
+}
+
+func TestConnBeginTx_PassWrappedTxContextCommit(t *testing.T) {
+	driverName := driverName(t)
+
+	con := &fakeConn{}
+	fakeTx := &fakeTx{}
+	con.tx = fakeTx
+
+	ti := &connTestInterceptor{T: t}
+
+	sql.Register(
+		driverName,
+		Driver(&fakeDriver{conn: con}, ti),
+	)
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("Failed to open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Failed to close db: %v", err)
+		}
+	})
+
+	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		t.Fatalf("Prepare failed: %s", err)
+	}
+
+	tx.Commit()
+
+	if !ti.TxCommitValid {
+		t.Error("TxCommit context not valid")
+	}
+
+}
+func TestConnBeginTx_PassWrappedTxContextRollback(t *testing.T) {
+	driverName := driverName(t)
+
+	con := &fakeConn{}
+	fakeTx := &fakeTx{}
+	con.tx = fakeTx
+
+	ti := &connTestInterceptor{T: t}
+
+	sql.Register(
+		driverName,
+		Driver(&fakeDriver{conn: con}, ti),
+	)
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("Failed to open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Failed to close db: %v", err)
+		}
+	})
+
+	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		t.Fatalf("Prepare failed: %s", err)
+	}
+
+	tx.Rollback()
+
+	if !ti.TxRollbackValid {
+		t.Error("TxRollback context not valid")
+	}
+}

--- a/fakedb_test.go
+++ b/fakedb_test.go
@@ -16,6 +16,12 @@ func (d *fakeDriver) Open(_ string) (driver.Conn, error) {
 	return d.conn, nil
 }
 
+type fakeTx struct{}
+
+func (f fakeTx) Commit() error { return nil }
+
+func (f fakeTx) Rollback() error { return nil }
+
 type fakeStmt struct {
 	rows   driver.Rows
 	called bool // nolint:structcheck // ignore unused warning, it is accessed via reflection
@@ -42,6 +48,10 @@ func (s fakeStmt) Exec(_ []driver.Value) (driver.Result, error) {
 }
 
 func (s fakeStmt) Query(_ []driver.Value) (driver.Rows, error) {
+	return s.rows, nil
+}
+
+func (s fakeStmt) QueryContext(_ context.Context, _ []driver.NamedValue) (driver.Rows, error) {
 	return s.rows, nil
 }
 
@@ -184,6 +194,7 @@ type fakeConn struct {
 	called          bool // nolint:structcheck // ignore unused warning, it is accessed via reflection
 	rowsCloseCalled bool
 	stmt            driver.Stmt
+	tx              driver.Tx
 }
 
 type fakeConnWithCheckNamedValue struct {
@@ -202,9 +213,13 @@ func (c *fakeConn) PrepareContext(_ context.Context, _ string) (driver.Stmt, err
 	return c.stmt, nil
 }
 
+func (c *fakeConn) ExecContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+	return nil, nil
+}
+
 func (c *fakeConn) Close() error { return nil }
 
-func (c *fakeConn) Begin() (driver.Tx, error) { return nil, nil }
+func (c *fakeConn) Begin() (driver.Tx, error) { return c.tx, nil }
 
 func (c *fakeConn) QueryContext(_ context.Context, _ string, nvs []driver.NamedValue) (driver.Rows, error) {
 	if c.stmt == nil {

--- a/stmt.go
+++ b/stmt.go
@@ -56,7 +56,7 @@ func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 
 func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
 	wrappedParent := wrappedParentStmt{Stmt: s.parent}
-	rows, err = s.intr.StmtQueryContext(ctx, wrappedParent, s.query, args)
+	ctx, rows, err = s.intr.StmtQueryContext(ctx, wrappedParent, s.query, args)
 	if err != nil {
 		return nil, err
 	}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -1,0 +1,99 @@
+package sqlmw
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+)
+
+const (
+	stmtRowContextKey   = "rowcontext"
+	stmtRowContextValue = "rowvalue"
+)
+
+type stmtTestInterceptor struct {
+	T              *testing.T
+	RowsNextValid  bool
+	RowsCloseValid bool
+	NullInterceptor
+}
+
+func (i *stmtTestInterceptor) StmtQueryContext(ctx context.Context, stmt driver.StmtQueryContext, _ string, args []driver.NamedValue) (context.Context, driver.Rows, error) {
+	ctx = context.WithValue(ctx, stmtRowContextKey, stmtRowContextValue)
+
+	r, err := stmt.QueryContext(ctx, args)
+	return ctx, r, err
+}
+
+func (i *stmtTestInterceptor) RowsNext(ctx context.Context, rows driver.Rows, dest []driver.Value) error {
+	if ctx.Value(stmtRowContextKey) == stmtRowContextValue {
+		i.RowsNextValid = true
+	}
+
+	i.T.Log(ctx)
+
+	return rows.Next(dest)
+}
+
+func (i *stmtTestInterceptor) RowsClose(ctx context.Context, rows driver.Rows) error {
+	if ctx.Value(stmtRowContextKey) == stmtRowContextValue {
+		i.RowsCloseValid = true
+	}
+
+	i.T.Log(ctx)
+
+	return rows.Close()
+}
+
+func TestStmtQueryContext_PassWrappedRowContext(t *testing.T) {
+	driverName := driverName(t)
+
+	con := &fakeConn{}
+	fakeStmt := &fakeStmt{
+		rows: &fakeRows{
+			con:  con,
+			vals: [][]driver.Value{{}},
+		},
+	}
+	con.stmt = fakeStmt
+
+	ti := &stmtTestInterceptor{T: t}
+
+	sql.Register(
+		driverName,
+		Driver(&fakeDriver{conn: con}, ti),
+	)
+
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("Failed to open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Failed to close db: %v", err)
+		}
+	})
+
+	stmt, err := db.PrepareContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Prepare failed: %s", err)
+	}
+
+	rows, err := stmt.Query("")
+	if err != nil {
+		t.Fatalf("Stmt query failed: %s", err)
+	}
+
+	rows.Next()
+	rows.Close()
+	stmt.Close()
+
+	if !ti.RowsNextValid {
+		t.Error("RowsNext context not valid")
+	}
+	if !ti.RowsCloseValid {
+		t.Error("RowsClose context not valid")
+	}
+}


### PR DESCRIPTION
Allows editing the transaction and statement context to add, for example, trace timestamp or other user data that we can retrieve on statement close, commit or rollback.

Signed-off-by: Antoine Deschênes <antoine@antoinedeschenes.com>