### PR TITLE
Allow driver.Connector wrapping

### DIFF
--- a/conn_go110.go
+++ b/conn_go110.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package sqlmw

--- a/conn_go115.go
+++ b/conn_go115.go
@@ -1,3 +1,4 @@
+//go:build go1.15
 // +build go1.15
 
 package sqlmw

--- a/conn_go19.go
+++ b/conn_go19.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package sqlmw

--- a/connector.go
+++ b/connector.go
@@ -17,7 +17,9 @@ var (
 	_ driver.Connector = wrappedConnector{}
 )
 
-func Connector(driverRef *wrappedDriver, connector driver.Connector) driver.Connector {
+// WrapConnector returns the supplied driver.Connector wrapped in a new object that has all of its calls intercepted by
+// the Interceptor in the supplied driver.
+func WrapConnector(driverRef *wrappedDriver, connector driver.Connector) wrappedConnector {
 	return wrappedConnector{driverRef: driverRef, parent: connector}
 }
 

--- a/connector.go
+++ b/connector.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package sqlmw
@@ -15,6 +16,10 @@ type wrappedConnector struct {
 var (
 	_ driver.Connector = wrappedConnector{}
 )
+
+func Connector(driverRef *wrappedDriver, connector driver.Connector) driver.Connector {
+	return wrappedConnector{driverRef: driverRef, parent: connector}
+}
 
 func (c wrappedConnector) Connect(ctx context.Context) (conn driver.Conn, err error) {
 	conn, err = c.driverRef.intr.ConnectorConnect(ctx, c.parent)

--- a/driver.go
+++ b/driver.go
@@ -13,17 +13,23 @@ var (
 	_ driver.Driver = wrappedDriver{}
 )
 
-// WrapDriver will wrap the passed SQL driver and return a new sql driver that uses it and also logs and traces calls using the passed logger and tracer
-// The returned driver will still have to be registered with the sql package before it can be used.
-//
-
-// Driver returns the supplied driver.Driver with a new object that has all of its calls intercepted by the supplied
-// Interceptor object.
+// WrapDriver returns the supplied driver.Driver wrapped in a new object that has all of its calls intercepted by the
+// supplied Interceptor object.
 //
 // Important note: Seeing as the context passed into the various instrumentation calls this package calls,
 // Any call without a context passed will not be intercepted. Please be sure to use the ___Context() and BeginTx()
 // function calls added in Go 1.8 instead of the older calls which do not accept a context.
-func Driver(driver driver.Driver, intr Interceptor) wrappedDriver {
+func WrapDriver(driver driver.Driver, intr Interceptor) wrappedDriver {
+	return wrappedDriver{parent: driver, intr: intr}
+}
+
+// WrapDriver returns the supplied driver.Driver wrapped in a new object that has all of its calls intercepted by the
+// supplied Interceptor object.
+//
+// Important note: Seeing as the context passed into the various instrumentation calls this package calls,
+// Any call without a context passed will not be intercepted. Please be sure to use the ___Context() and BeginTx()
+// function calls added in Go 1.8 instead of the older calls which do not accept a context.
+func Driver(driver driver.Driver, intr Interceptor) driver.Driver {
 	return wrappedDriver{parent: driver, intr: intr}
 }
 

--- a/driver.go
+++ b/driver.go
@@ -23,7 +23,7 @@ var (
 // Important note: Seeing as the context passed into the various instrumentation calls this package calls,
 // Any call without a context passed will not be intercepted. Please be sure to use the ___Context() and BeginTx()
 // function calls added in Go 1.8 instead of the older calls which do not accept a context.
-func Driver(driver driver.Driver, intr Interceptor) driver.Driver {
+func Driver(driver driver.Driver, intr Interceptor) wrappedDriver {
 	return wrappedDriver{parent: driver, intr: intr}
 }
 

--- a/driver_go110.go
+++ b/driver_go110.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package sqlmw
@@ -9,15 +10,11 @@ var _ driver.DriverContext = wrappedDriver{}
 func (d wrappedDriver) OpenConnector(name string) (driver.Connector, error) {
 	driver, ok := d.parent.(driver.DriverContext)
 	if !ok {
-		return wrappedConnector{
-			parent:    dsnConnector{dsn: name, driver: d.parent},
-			driverRef: &d,
-		}, nil
+		return WrapConnector(&d, dsnConnector{dsn: name, driver: d.parent}), nil
 	}
 	conn, err := driver.OpenConnector(name)
 	if err != nil {
 		return nil, err
 	}
-
-	return wrappedConnector{parent: conn, driverRef: &d}, nil
+	return WrapConnector(&d, conn), nil
 }


### PR DESCRIPTION
Depending on the driver we might have easy access to a configurable `driver.Connector`, but not a configurable `driver.Driver`. This change adds a couple new functions so we can wrap a `driver.Connector` instead of a driver; in my case, it's useful when used together with `jackc/pgx`:

```
pgxConnConfig, err := pgx.ParseConfig(dsn)
if err != nil {
    return nil, errors.WithStack(err)
}

driver := sqlmw.WrapDriver(pgxstdlib.GetDefaultDriver(), &sqlInterceptor{ApplicationName: applicationName})

connector := sqlmw.WrapConnector(
    &driver,
    pgxstdlib.GetConnector(
    	*pgxConnConfig,
    	pgxstdlib.OptionAfterConnect(func(ctx context.Context, pgxConn *pgx.Conn) error {
    		pgxConn.TypeMap().RegisterType(&pgtype.Type{Name: "timestamp", OID: pgtype.TimestampOID, Codec: &pgtype.TimestampCodec{ScanLocation: time.UTC}})
    		pgxConn.TypeMap().RegisterType(&pgtype.Type{Name: "timestamptz", OID: pgtype.TimestamptzOID, Codec: &pgtype.TimestamptzCodec{ScanLocation: time.UTC}})
    		return nil
    	}),
    ),
)

db := sql.OpenDB(connector)
```